### PR TITLE
GDB-12997 Fix form not updating, when additional instructions are copied during agent creation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default [
         setInterval: 'readonly',
         clearInterval: 'readonly',
         MutationObserver: 'readonly',
+        Event: 'readonly',
 
         // AngularJS globals
         angular: 'readonly',

--- a/plugins/guides/utils.js
+++ b/plugins/guides/utils.js
@@ -22,6 +22,7 @@ export const createCopyToInputListener = (elementSelector, text) => {
     event.preventDefault();
     const inputElement = document.querySelector(elementSelector);
     inputElement.value = text;
+    inputElement.dispatchEvent(new Event('input', {bubbles: true}));
   };
 };
 

--- a/scripts/post-jsdoc.js
+++ b/scripts/post-jsdoc.js
@@ -12,7 +12,7 @@ function removeFooterFromHtmlFiles(dirPath) {
   try {
     const files = fs.readdirSync(dirPath);
 
-    files.forEach(file => {
+    files.forEach((file) => {
       const filePath = path.join(dirPath, file);
       const stat = fs.statSync(filePath);
 


### PR DESCRIPTION
## What
Fix form not updating, when copying additional instructions from the TTYG guide

## Why
It wasn't being sent in the request to the backend. As a result the agent is created without them and behaves unexpectedly.

## How
Dispatched an input event inside `validateTextInput`. This way angular triggers a digest cycle and the form is updated and sent in the request.

## Testing
n/a