### PR TITLE
GDB-12988 Fix wrong position on create agent step

### DIFF
--- a/plugins/guides/ttyg/create-ttyg-agent.js
+++ b/plugins/guides/ttyg/create-ttyg-agent.js
@@ -21,6 +21,14 @@ const step = {
         options: {...options}
       },
       {
+        guideBlockName: 'wait-for-element-to-hide',
+        options: {
+          ...options,
+          elementSelectorToHide: GuideUtils.getElementSelector('.ttyg-page-loader'),
+          timeToWait: 10
+        }
+      },
+      {
         guideBlockName: 'ttyg-create-agent-click', options: {...options}
       },
       {
@@ -33,10 +41,11 @@ const step = {
       },
       {
         guideBlockName: 'wait-for-element-to-hide',
-        options: angular.extend({}, {
+        options: {
+          ...options,
           elementSelectorToHide: GuideUtils.getElementSelector('.agent-settings-modal'),
           timeToWait: 10
-        }, options)
+        }
       }
     ];
   }


### PR DESCRIPTION
## What
Fix wrong position of create agent step

## Why
It was positioning the dialog in the top left corner

## How
Added `wait-for-element-to-hide` step, before the create agent step. We wait for the container of the spinner to hide, since it is the element, which has a `display none` applied to it. This way the button is visible, when it is time to position the step on top of it

## Testing
n/a