### PR TITLE
GDB-12984: Add guide steps for connectors view

### DIFF
--- a/plugins/guides/connectors/connectors-array-subparameter-intro.js
+++ b/plugins/guides/connectors/connectors-array-subparameter-intro.js
@@ -1,0 +1,49 @@
+import {
+    CONNECTORS_DEFAULT_TITLE,
+    getConnectorContentSelector,
+    getConnectorNameSelector,
+    getConnectorParameterSelector,
+    getConnectorSubparameterSelector
+} from "../utils.js";
+
+const step = {
+    guideBlockName: 'connectors-array-subparameter-intro',
+    /**
+     * Options:
+     * - <b>connectorName</b>: string (required).
+     *   <ol>Possible values:
+     *    <li>Elasticsearch</li>
+     *    <li>OpenSearch</li>
+     *    <li>Solr</li>
+     *    <li>Lucene</li>
+     *    <li>Kafka</li>
+     *    <li>ChatGPT-Retrieval</li>
+     *   </ol>
+     * - <b>instanceName</b>: string (required) – the specific connector instance name for <code>connectorName</code>.
+     * - <b>parameterName</b>: string (required) – the specific creation parameter name for <code>instanceName</code>.
+     * - <b>subparameterName</b>: string (required) – the specific creation subparameter name for <code>parameterName</code>.
+     */
+    getSteps: (options, services) => {
+        const connectorNameSelector = getConnectorNameSelector(options, services);
+        const connectorContentSelector = getConnectorContentSelector(options, services);
+        const parameterSelector = getConnectorParameterSelector(options, services);
+        const subparameterName = getConnectorSubparameterSelector(options, services);
+        return [{
+            guideBlockName: 'read-only-element',
+            options: {
+                // If mainAction is set the title will be set automatically
+                ...(options.mainAction ? {} : {title: CONNECTORS_DEFAULT_TITLE}),
+                placement: 'top',
+                class: 'connectors-connector-intro',
+                content: 'guide.step_plugin.connectors-array-subparameter-intro.content',
+                ...options,
+                elementSelector: `${connectorNameSelector} ${connectorContentSelector} ${parameterSelector} ${subparameterName}`,
+                url: 'connectors',
+            },
+        }];
+    },
+};
+
+export function register(registry) {
+    registry.add('guide.step', step);
+}

--- a/plugins/guides/connectors/connectors-close-view-sparql-query-dialog.js
+++ b/plugins/guides/connectors/connectors-close-view-sparql-query-dialog.js
@@ -1,0 +1,29 @@
+import {CONNECTORS_DEFAULT_TITLE} from "../utils.js";
+
+const step = {
+    guideBlockName: 'connectors-close-view-sparql-query-dialog',
+    getSteps: (options, services) => {
+        const GuideUtils = services.GuideUtils;
+        const elementSelector = GuideUtils.getGuideElementSelector('close-view-query-dialog');
+        return [{
+            guideBlockName: 'clickable-element',
+            options: {
+                // If mainAction is set the title will be set automatically
+                ...(options.mainAction ? {} : {title: CONNECTORS_DEFAULT_TITLE}),
+                placement: 'top',
+                class: 'connectors-close-view-sparql-query-dialog',
+                content: 'guide.step_plugin.connectors-close-view-sparql-query-dialog.content',
+                ...options,
+                elementSelector,
+                url: 'connectors',
+                onNextClick: () => {
+                    GuideUtils.clickOnElement(elementSelector)();
+                },
+            },
+        }];
+    },
+};
+
+export function register(registry) {
+    registry.add('guide.step', step);
+}

--- a/plugins/guides/connectors/connectors-connector-intro.js
+++ b/plugins/guides/connectors/connectors-connector-intro.js
@@ -1,0 +1,40 @@
+import {CONNECTORS_DEFAULT_TITLE, getConnectorNameSelector} from "../utils.js";
+
+const step = {
+    guideBlockName: 'connectors-connector-intro',
+    /**
+     * Options:
+     * - <b>connectorName</b>: string (required).
+     *   <ol>Possible values:
+     *    <li>Elasticsearch</li>
+     *    <li>OpenSearch</li>
+     *    <li>Solr</li>
+     *    <li>Lucene</li>
+     *    <li>Kafka</li>
+     *    <li>ChatGPT-Retrieval</li>
+     *   </ol>
+     * - <b>instanceName</b>: string (required) – the specific connector instance name for <code>connectorName</code>.
+     */
+    getSteps: (options, services) => {
+        const GuideUtils = services.GuideUtils;
+        const connectorNameSelector = getConnectorNameSelector(options, services);
+        const connectorCardSelector = GuideUtils.getGuideElementSelector(`${options.instanceName}-connector-card`);
+        return [{
+            guideBlockName: 'read-only-element',
+            options: {
+                // If mainAction is set the title will be set automatically
+                ...(options.mainAction ? {} : {title: CONNECTORS_DEFAULT_TITLE}),
+                placement: 'top',
+                class: 'connectors-connector-intro',
+                content: 'guide.step_plugin.connectors-connector-intro.content',
+                ...options,
+                elementSelector: `${connectorNameSelector} ${connectorCardSelector}`,
+                url: 'connectors',
+            },
+        }];
+    },
+};
+
+export function register(registry) {
+    registry.add('guide.step', step);
+}

--- a/plugins/guides/connectors/connectors-expand-connector.js
+++ b/plugins/guides/connectors/connectors-expand-connector.js
@@ -1,0 +1,43 @@
+import {CONNECTORS_DEFAULT_TITLE, getConnectorNameSelector} from "../utils.js";
+
+const step = {
+    guideBlockName: 'connectors-expand-connector',
+    /**
+     * Options:
+     * - <b>connectorName</b>: string (required).
+     *   <ol>Possible values:
+     *    <li>Elasticsearch</li>
+     *    <li>OpenSearch</li>
+     *    <li>Solr</li>
+     *    <li>Lucene</li>
+     *    <li>Kafka</li>
+     *    <li>ChatGPT-Retrieval</li>
+     *   </ol>
+     * - <b>instanceName</b>: string (required) – the specific connector instance name for <code>connectorName</code>.
+     */
+    getSteps: (options, services) => {
+        const GuideUtils = services.GuideUtils;
+        const connectorNameSelector = getConnectorNameSelector(options, services);
+        const connectorToggleButtonSelector = GuideUtils.getGuideElementSelector(`${options.instanceName}-connector-toggle-button`, 'a');
+        return [{
+            guideBlockName: 'clickable-element',
+            options: {
+                // If mainAction is set the title will be set automatically
+                ...(options.mainAction ? {} : {title: CONNECTORS_DEFAULT_TITLE}),
+                placement: 'top',
+                class: 'connectors-expand-connector',
+                content: 'guide.step_plugin.connectors-expand-connector.content',
+                ...options,
+                elementSelector: `${connectorNameSelector} ${connectorToggleButtonSelector}`,
+                url: 'connectors',
+                onNextClick: () => {
+                    GuideUtils.clickOnElement(`${connectorNameSelector} ${connectorToggleButtonSelector}`)();
+                },
+            },
+        }];
+    },
+};
+
+export function register(registry) {
+    registry.add('guide.step', step);
+}

--- a/plugins/guides/connectors/connectors-intro.js
+++ b/plugins/guides/connectors/connectors-intro.js
@@ -1,0 +1,23 @@
+import {CONNECTORS_DEFAULT_TITLE} from "../utils.js";
+
+const step = {
+    guideBlockName: 'connectors-intro',
+    getSteps: (options) => {
+        return [{
+            guideBlockName: 'info-message',
+            options: {
+                // If mainAction is set the title will be set automatically
+                ...(options.mainAction ? {} : {title: CONNECTORS_DEFAULT_TITLE}),
+                placement: 'top',
+                class: 'connectors-connectors-intro',
+                content: 'guide.step_plugin.connectors-connectors-intro.content',
+                ...options,
+                url: 'connectors',
+            },
+        }];
+    },
+};
+
+export function register(registry) {
+    registry.add('guide.step', step);
+}

--- a/plugins/guides/connectors/connectors-open-view-sparql-query-dialog.js
+++ b/plugins/guides/connectors/connectors-open-view-sparql-query-dialog.js
@@ -1,0 +1,45 @@
+import {CONNECTORS_DEFAULT_TITLE, getConnectorContentSelector, getConnectorNameSelector} from "../utils.js";
+
+const step = {
+    guideBlockName: 'connectors-open-view-sparql-query-dialog',
+    /**
+     * Options:
+     * - <b>connectorName</b>: string (required).
+     *   <ol>Possible values:
+     *    <li>Elasticsearch</li>
+     *    <li>OpenSearch</li>
+     *    <li>Solr</li>
+     *    <li>Lucene</li>
+     *    <li>Kafka</li>
+     *    <li>ChatGPT-Retrieval</li>
+     *   </ol>
+     * - <b>instanceName</b>: string (required) – the specific connector instance name for <code>connectorName</code>.
+     */
+    getSteps: (options, services) => {
+        const GuideUtils = services.GuideUtils;
+        const connectorNameSelector = getConnectorNameSelector(options, services);
+        const connectorContentSelector = getConnectorContentSelector(options, services);
+        const openViewSPARQLDialogSelector = GuideUtils.getGuideElementSelector('open-view-sparql-query-dialog');
+        const elementSelector = `${connectorNameSelector} ${connectorContentSelector} ${openViewSPARQLDialogSelector}`;
+        return [{
+            guideBlockName: 'clickable-element',
+            options: {
+                // If mainAction is set the title will be set automatically
+                ...(options.mainAction ? {} : {title: CONNECTORS_DEFAULT_TITLE}),
+                placement: 'top',
+                class: 'open-view-sparql-query-dialog',
+                content: 'guide.step_plugin.connectors-open-view-sparql-query-dialog.content',
+                ...options,
+                elementSelector,
+                url: 'connectors',
+                onNextClick: () => {
+                    GuideUtils.clickOnElement(elementSelector)();
+                },
+            },
+        }];
+    },
+};
+
+export function register(registry) {
+    registry.add('guide.step', step);
+}

--- a/plugins/guides/connectors/connectors-parameter-intro.js
+++ b/plugins/guides/connectors/connectors-parameter-intro.js
@@ -1,0 +1,41 @@
+import {CONNECTORS_DEFAULT_TITLE, getConnectorContentSelector, getConnectorNameSelector, getConnectorParameterSelector} from "../utils.js";
+
+const step = {
+    guideBlockName: 'connectors-parameter-intro',
+    /**
+     * Options:
+     * - <b>connectorName</b>: string (required).
+     *   <ol>Possible values:
+     *    <li>Elasticsearch</li>
+     *    <li>OpenSearch</li>
+     *    <li>Solr</li>
+     *    <li>Lucene</li>
+     *    <li>Kafka</li>
+     *    <li>ChatGPT-Retrieval</li>
+     *   </ol>
+     * - <b>instanceName</b>: string (required) – the specific connector instance name for <code>connectorName</code>.
+     * - <b>parameterName</b>: string (required) – the specific creation parameters name for <code>instanceName</code>.
+     */
+    getSteps: (options, services) => {
+        const connectorNameSelector = getConnectorNameSelector(options, services);
+        const connectorContentSelector = getConnectorContentSelector(options, services);
+        const parameterSelector = getConnectorParameterSelector(options, services);
+        return [{
+            guideBlockName: 'read-only-element',
+            options: {
+                // If mainAction is set the title will be set automatically
+                ...(options.mainAction ? {} : {title: CONNECTORS_DEFAULT_TITLE}),
+                placement: 'top',
+                class: 'connectors-connector-intro',
+                content: 'guide.step_plugin.connectors-parameter-intro.content',
+                ...options,
+                elementSelector: `${connectorNameSelector} ${connectorContentSelector} ${parameterSelector}`,
+                url: 'connectors',
+            },
+        }];
+    },
+};
+
+export function register(registry) {
+    registry.add('guide.step', step);
+}

--- a/plugins/guides/connectors/connectors-type-intro.js
+++ b/plugins/guides/connectors/connectors-type-intro.js
@@ -1,0 +1,38 @@
+import {CONNECTORS_DEFAULT_TITLE, getConnectorNameSelector} from "../utils.js";
+
+const step = {
+    guideBlockName: 'connectors-type-intro',
+    /**
+     * Options:
+     * - <b>connectorName</b>: string (required).
+     *   <ol>Possible values:
+     *    <li>Elasticsearch</li>
+     *    <li>OpenSearch</li>
+     *    <li>Solr</li>
+     *    <li>Lucene</li>
+     *    <li>Kafka</li>
+     *    <li>ChatGPT-Retrieval</li>
+     *   </ol>
+     *
+     *   Must override content with connector specific content
+     */
+    getSteps: (options, services) => {
+        return [{
+            guideBlockName: 'read-only-element',
+            options: {
+                // If mainAction is set the title will be set automatically
+                ...(options.mainAction ? {} : {title: CONNECTORS_DEFAULT_TITLE}),
+                placement: 'top',
+                class: 'connectors-connectors-intro',
+                content: 'guide.step_plugin.connectors-type-intro.content',
+                ...options,
+                elementSelector: getConnectorNameSelector(options, services),
+                url: 'connectors',
+            },
+        }];
+    },
+};
+
+export function register(registry) {
+    registry.add('guide.step', step);
+}

--- a/plugins/guides/connectors/connectors-view-sparql-dialog-intro.js
+++ b/plugins/guides/connectors/connectors-view-sparql-dialog-intro.js
@@ -1,0 +1,26 @@
+import {CONNECTORS_DEFAULT_TITLE} from "../utils.js";
+
+const step = {
+    guideBlockName: 'connectors-view-sparql-dialog-intro',
+    getSteps: (options, services) => {
+        const GuideUtils = services.GuideUtils;
+        return [{
+            guideBlockName: 'scroll-only-element',
+            options: {
+                // If mainAction is set the title will be set automatically
+                ...(options.mainAction ? {} : {title: CONNECTORS_DEFAULT_TITLE}),
+                placement: 'left',
+                class: 'connectors-view-sparql-dialog-intro',
+                content: 'guide.step_plugin.connectors-view-sparql-dialog-intro.content',
+                ...options,
+                elementSelectorToWait: GuideUtils.getGuideElementSelector('view-query-body'),
+                elementSelector: GuideUtils.getGuideElementSelector('view-query-body'),
+                url: 'connectors',
+            },
+        }];
+    },
+};
+
+export function register(registry) {
+    registry.add('guide.step', step);
+}

--- a/plugins/guides/utils.js
+++ b/plugins/guides/utils.js
@@ -79,6 +79,7 @@ export const TTYG_DEFAULT_TITLE = 'menu.ttyg.label';
 export const FTS_METHOD_DEFAULT_TITLE = 'guide.step-action.fts-search-method';
 export const SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE = 'guide.step-action.similarity-search-method';
 export const TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE = 'guide.step-action.sparql-search-method';
+export const CONNECTORS_DEFAULT_TITLE = 'menu.connectors.label';
 
 // Configuration options constants
 export const CONFIGURATION_OPTION_ONTOLOGY_GRAPH = 'ontologyGraph';
@@ -168,4 +169,20 @@ export const getWaitForAnswerStep = (GuideUtils, options) => {
       elementSelectorToWait: GuideUtils.getGuideElementSelector('question-loader')
     }, options)
   };
+};
+
+export const getConnectorNameSelector = (options, services) => {
+    return services.GuideUtils.getGuideElementSelector(`connector-name-${options.connectorName}`);
+};
+
+export const getConnectorContentSelector = (options, services) => {
+    return services.GuideUtils.getGuideElementSelector(`${options.instanceName}-connector-content`);
+};
+
+export const getConnectorParameterSelector = (options, services) => {
+    return services.GuideUtils.getGuideElementSelector(`${options.parameterName}-connector-parameter`);
+};
+
+export const getConnectorSubparameterSelector = (options, services) => {
+    return services.GuideUtils.getGuideElementSelector(`${options.subparameterName}-connector-subproperty`);
 };


### PR DESCRIPTION
## What
Implemented new guide steps for various connectors, enhancing user interaction and guidance.

## Why
These changes provide users with clearer instructions on how to interact with different connectors, improving the overall user experience.

## How
- Created new guide steps for `connectors-array-subparameter-intro`, `connectors-close-view-sparql-query-dialog`, `connectors-connector-intro`, `connectors-expand-connector`, `connectors-intro`, `connectors-open-view-sparql-query-dialog`, `connectors-parameter-intro`, `connectors-type-intro`, and `connectors-view-sparql-dialog-intro`.
- Updated `utils.js` to include utility functions for selecting connector elements.
- Ensured each step includes options for titles, placements, and content relevant to the connectors.