### PR TITLE
GDB-13062: Decouple guides translation from Workbench language bundles

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,4 +12,5 @@ fi
 # Run your checks
 npm run validate-manifest
 npm run document
+npm run validate-translations
 npx eslint . --max-warnings 1000

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -86,7 +86,8 @@ export default [
     ignores: [
       'node_modules/**',
       'dist/**',
-      'docs/**'
+      'docs/**',
+      'scripts/validate-translations.cjs'
     ]
   }
 ];

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "document": "npm run pre:document && jsdoc -c jsdoc.config.json && npm run post:document",
     "build": "npm run validate-manifest && webpack --config webpack.config.js",
     "validate-manifest": "node scripts/validate-manifest.js",
+    "validate-translations": "node scripts/validate-translations.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "install:ci": "npm ci",

--- a/plugins/guides/autocomplete/autocomplete-enable-checkbox.js
+++ b/plugins/guides/autocomplete/autocomplete-enable-checkbox.js
@@ -1,4 +1,5 @@
-import * as Utils from '../utils.js';
+import {translate} from '../../../utils/translations/translation-service.js';
+import {ENABLE_AUTOCOMPLETE_DEFAULT_TITLE} from '../utils.js';
 
 const step = {
   guideBlockName: 'autocomplete-enable-checkbox',
@@ -11,9 +12,9 @@ const step = {
       {
         guideBlockName: 'clickable-element',
         options: {
-          content: 'guide.step_plugin.enable-autocomplete.content',
+          content: translate(options.language, 'guide.step_plugin.enable-autocomplete.content'),
           // If mainAction is set the title will be set automatically
-          ...(options.mainAction ? {} : {title: Utils.ENABLE_AUTOCOMPLETE_DEFAULT_TITLE}),
+          ...(options.mainAction ? {} : {title: translate(options.language, ENABLE_AUTOCOMPLETE_DEFAULT_TITLE)}),
           class: 'enable-autocomplete-checkbox',
           ...options,
           url: 'autocomplete',

--- a/plugins/guides/autocomplete/autocomplete-focus-on-indexing-status.js
+++ b/plugins/guides/autocomplete/autocomplete-focus-on-indexing-status.js
@@ -1,4 +1,5 @@
-import * as Utils from '../utils.js';
+import {ENABLE_AUTOCOMPLETE_DEFAULT_TITLE} from '../utils.js';
+import {translate} from '../../../utils/translations/translation-service.js';
 
 const step = {
   guideBlockName: 'autocomplete-focus-on-indexing-status',
@@ -8,9 +9,9 @@ const step = {
     return {
       guideBlockName: 'read-only-element',
       options: {
-        content: 'guide.step_plugin.enable-autocomplete.status_info.content',
+        content: translate(options.language, 'guide.step_plugin.enable-autocomplete.status_info.content'),
         // If mainAction is set the title will be set automatically
-        ...(options.mainAction ? {} : {title: Utils.ENABLE_AUTOCOMPLETE_DEFAULT_TITLE}),
+        ...(options.mainAction ? {} : {title: translate(options.language, ENABLE_AUTOCOMPLETE_DEFAULT_TITLE)}),
         ...options,
         url: 'autocomplete',
         elementSelector: GuideUtils.getGuideElementSelector('autocompleteStatus'),

--- a/scripts/validate-translations.cjs
+++ b/scripts/validate-translations.cjs
@@ -1,0 +1,198 @@
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
+
+// Change this to the folder you want to validate
+const i18nDir = path.resolve(__dirname, '..', 'utils', 'translations', 'i18n');
+const localeRegex = /^(?:locale-)?([a-z]{2})\.json$/;
+
+// Verified identical translations - no warnings or errors about them
+const identicalTranslations = [
+  "Active",
+  "Action",
+  "Actions",
+  "Agent: {{agentName}}",
+  "GraphQL",
+  "Mode",
+  "Type",
+  "Types",
+  "JSON",
+  "Turtle",
+  "SPARQL",
+  "N-Triples"
+];
+
+// Unverified identical or TODO translations - printed as warnings
+const toDoTranslations = [
+  "Dark",
+  "Nullable",
+  "Label IRI",
+  "Warehouse",
+  "horizontal"
+];
+
+/**
+ * Recursively collect all keys and values from a nested object.
+ */
+function getAllKeys(obj, valuesObj, prefix = '') {
+  return _.flatMap(obj, (value, key) => {
+    const newPrefix = prefix ? `${prefix}.${key}` : key;
+    valuesObj[newPrefix] = value;
+    if (_.isObject(value) && !_.isArray(value)) {
+      return getAllKeys(value, valuesObj, newPrefix);
+    }
+    return newPrefix;
+  });
+}
+
+/**
+ * Detect differences in HTML tags between two strings.
+ */
+function hasHtmlTagDifference(en, fr) {
+  function tagDiff(a, b) {
+    const re = /(<[^<>]+>)/g;
+    return _.difference(a.match(re), b.match(re));
+  }
+  if (!en || !fr) return false;
+  return !_.isEmpty(tagDiff(en, fr)) || !_.isEmpty(tagDiff(fr, en));
+}
+
+/**
+ * Detect differences in placeholders like {{…}} between two strings.
+ */
+function hasPlaceholderDifference(en, fr) {
+  function placeholderDiff(a, b) {
+    const re = /(\{\{.+?}})/g;
+    return _.difference(a.match(re), b.match(re));
+  }
+  if (!en || !fr) return false;
+  return !_.isEmpty(placeholderDiff(en, fr)) || !_.isEmpty(placeholderDiff(fr, en));
+}
+
+/**
+ * Determine if a translation is untranslated (identical to English and not in identical/TODO lists).
+ */
+function isUntranslated(en, fr) {
+  if (en === fr) {
+    const isIdentical = identicalTranslations.includes(en);
+    const isTodo = toDoTranslations.includes(en);
+    if (isTodo) {
+      console.warn("TODO translate: " + en);
+    }
+    return !isIdentical && !isTodo;
+  } else if (toDoTranslations.includes(en)) {
+    console.warn("TODO no longer identical - remove from TODO list: " + en + " => " + fr);
+  }
+  return false;
+}
+
+/**
+ * Validate a translation bundle against English.
+ */
+function validate(enObj, frObj) {
+  function compare(en, fr, fn) {
+    if (fn(en, fr)) {
+      return { en, fr };
+    }
+  }
+
+  const enValues = {};
+  const enKeys = getAllKeys(enObj, enValues);
+  const frValues = {};
+  const frKeys = getAllKeys(frObj, frValues);
+
+  const missingKeys = _.difference(enKeys, frKeys);
+  const obsoleteKeys = _.difference(frKeys, enKeys);
+
+  const htmlTagDifferences = {};
+  const placeholderDifferences = {};
+  const untranslated = {};
+
+  enKeys.forEach((key) => {
+    const en = enValues[key];
+    const fr = frValues[key];
+
+    const htmlDiff = compare(en, fr, hasHtmlTagDifference);
+    if (htmlDiff) {
+      htmlTagDifferences[key] = htmlDiff;
+    }
+    const pDiff = compare(en, fr, hasPlaceholderDifference);
+    if (pDiff) {
+      placeholderDifferences[key] = pDiff;
+    }
+    const untranslatedKey = compare(en, fr, isUntranslated);
+    if (untranslatedKey) {
+      untranslated[key] = untranslatedKey;
+    }
+  });
+
+  const isValid =
+    _.isEmpty(missingKeys) &&
+    _.isEmpty(obsoleteKeys) &&
+    _.isEmpty(htmlTagDifferences) &&
+    _.isEmpty(placeholderDifferences) &&
+    _.isEmpty(untranslated);
+
+  return {
+    isValid,
+    missingKeys,
+    obsoleteKeys,
+    htmlTagDifferences,
+    placeholderDifferences,
+    untranslated
+  };
+}
+
+function loadTranslations() {
+  const bundles = {};
+  fs.readdirSync(i18nDir).forEach(file => {
+    const match = file.match(localeRegex);
+    if (!match) return;
+    const lang = match[1];
+    const content = JSON.parse(fs.readFileSync(path.join(i18nDir, file), 'utf8'));
+    bundles[lang] = content;
+  });
+  return bundles;
+}
+
+function main() {
+  const bundles = loadTranslations();
+  const enBundle = bundles['en'] || {};
+
+  let hasErrors = false;
+
+  Object.entries(bundles).forEach(([lang, bundle]) => {
+    if (lang === 'en') return;
+
+    const res = validate(enBundle, bundle);
+    Object.entries(res).forEach(([type, data]) => {
+      if (type === 'isValid' || _.isEmpty(data)) return;
+
+      hasErrors = true;
+      console.error(`\n[${lang}] ${type}:`);
+      console.error(JSON.stringify(data, null, 2));
+    });
+  });
+
+  if (hasErrors) {
+    console.error('Issues found in translations.');
+    process.exit(1);
+  } else {
+    console.info('All translations are valid.');
+    process.exit(0);
+  }
+}
+
+if (require.main === module) {
+  console.info(`Validating translations in: ${i18nDir}`);
+  main();
+}
+
+module.exports = {
+  getAllKeys,
+  hasHtmlTagDifference,
+  hasPlaceholderDifference,
+  isUntranslated,
+  validate,
+  loadTranslations,
+};

--- a/utils/translations/i18n/locale-en.json
+++ b/utils/translations/i18n/locale-en.json
@@ -1,0 +1,4 @@
+{
+  "guide.step_plugin.enable-autocomplete.content": "Click on the checkbox to enable the index.",
+  "guide.step_plugin.enable-autocomplete.status_info.content": "Wait until indexing finished."
+}

--- a/utils/translations/i18n/locale-fr.json
+++ b/utils/translations/i18n/locale-fr.json
@@ -1,0 +1,4 @@
+{
+  "guide.step_plugin.enable-autocomplete.content": "Cliquez sur la case à cocher pour activer l'indexation.",
+  "guide.step_plugin.enable-autocomplete.status_info.content": "Attendez que l'indexation soit terminée."
+}

--- a/utils/translations/translation-service.js
+++ b/utils/translations/translation-service.js
@@ -1,0 +1,93 @@
+import en from './i18n/locale-en.json';
+import fr from './i18n/locale-fr.json';
+
+/**
+ * TranslationService provides translation capabilities.
+ */
+class TranslationService {
+  static DEFAULT_LANG = 'en';
+
+  static bundle = {
+    en,
+    fr
+  };
+
+  // Singleton instance holder
+  static _instance;
+
+  constructor() {
+    if (TranslationService._instance) {
+      return TranslationService._instance;
+    }
+    TranslationService._instance = this;
+  }
+
+  /**
+   * Get the singleton instance of TranslationService.
+   *
+   * @returns {TranslationService} The TranslationService instance.
+   */
+  static getInstance() {
+    if (!TranslationService._instance) {
+      TranslationService._instance = new TranslationService();
+    }
+    return TranslationService._instance;
+  }
+
+  /**
+   * Translate a key into the given locale. Falls back to the default language if missing.
+   *
+   * @param {string} locale - The target language (e.g. 'en', 'fr').
+   * @param {string} key - The translation key to look up.
+   * @param {Object<string, string>} [parameters={}] - Optional parameters for substitution.
+   * @returns {string} The translated string, or the key if missing.
+   */
+  translate(locale, key, parameters = {}) {
+    let translation = TranslationService.bundle[locale]?.[key];
+
+    if (!translation) {
+      // Fallback to the default language
+      translation = TranslationService.bundle[TranslationService.DEFAULT_LANG]?.[key];
+    }
+
+    if (translation) {
+      return this.applyParameters(translation, parameters);
+    }
+
+    // eslint-disable-next-line no-console
+    console.warn(`Missing translation for [${key}] key in [${locale}] locale`);
+    return key;
+  }
+
+  /**
+   * Replace placeholders in the translation string with given parameters.
+   *
+   * Example: 'Hello {{name}}' + { name: 'Alice' } → 'Hello Alice'
+   *
+   * @param {string} translation - The translation string with placeholders.
+   * @param {Object<string, string>} parameters - The parameters to replace.
+   * @returns {string} The translation with parameters applied.
+   */
+  applyParameters(translation, parameters = {}) {
+    return Object.entries(parameters).reduce(
+      (result, [paramKey, paramValue]) => this.replaceAll(result, paramKey, paramValue),
+      translation
+    );
+  }
+
+  /**
+   * Replace all occurrences of a single parameter placeholder in the translation.
+   *
+   * @param {string} translation - The translation string.
+   * @param {string} key - The placeholder key to replace.
+   * @param {string} value - The value to replace it with.
+   * @returns {string} The updated translation string.
+   */
+  replaceAll(translation, key, value) {
+    return translation.split(`{{${key}}}`).join(value);
+  }
+}
+
+const translationInstance = TranslationService.getInstance();
+export const translate = translationInstance.translate.bind(translationInstance);
+


### PR DESCRIPTION
## What
Implement translation directly within the guides plugin project:
- Added TranslationService with separate files per language
- Updated autocomplete steps contents and titles to use this service

## Why
Currently, guides translations depend on Workbench language bundles, creating unnecessary coupling between the guides plugin and the Workbench, even though they now belong to separate projects.

## How
- Create a translation service that uses separate files per language
- Update autocomplete steps and titles to consume translations from this service
- Introduce a `language` option provided by Workbench when a guide starts
- Default language falls back to `en` if no option is set