### PR TITLE
GDB-13076: Guide skips waiting for Similarity Index build

### DIFF
--- a/plugins/guides/similarity-index/similarity-hold-and-wait-until-shown.js
+++ b/plugins/guides/similarity-index/similarity-hold-and-wait-until-shown.js
@@ -4,6 +4,7 @@ const step = {
     const GuideUtils = services.GuideUtils;
     return [
       {
+        guideBlockName: 'hold-and-wait-until-shown',
         options: {
           content: 'guide.step_plugin.create-similarity-index.wait',
           class: 'wait-for-index',


### PR DESCRIPTION
## What
The step that instructs users to wait until a similarity index is created is skipped when the "create-similarity-index" step is used.

## Why
During the extraction of similarity steps from the complex, the skipped step was mistakenly left without a guideBlockName. This caused the guide to skip it

## How
Added the missing guideBlockName to the step.

<img width="840" height="405" alt="image" src="https://github.com/user-attachments/assets/128b5fad-a7f9-4748-a30b-3d2210bc531c" />