### PR TITLE
GDB-13086 fix TTYG dialog options to improve answer wait functionality

### DIFF
--- a/plugins/guides/utils.js
+++ b/plugins/guides/utils.js
@@ -199,14 +199,14 @@ export const enableAllVisualGraphNodes = () => () => {
 export const getWaitForAnswerStep = (GuideUtils, options) => {
   return {
     guideBlockName: 'hold-and-wait-until-hidden',
-    options: angular.extend({}, {
+    options: {
       content: 'guide.step_plugin.ask-ttyg-agent.wait-for-answer',
       class: 'wait-for-answer',
       url: 'ttyg',
-      placement: 'left',
       elementSelector: GuideUtils.getGuideElementSelector('chat-details'),
-      elementSelectorToWait: GuideUtils.getGuideElementSelector('question-loader')
-    }, options)
+      elementSelectorToWait: GuideUtils.getGuideElementSelector('question-loader'),
+      ...options
+    }
   };
 };
 


### PR DESCRIPTION
## What
Fix the placement of the guide step for the ttyg agent in the chat panel

## Why
On smaller screens, the dialog covers the chat panel

## How
Removed the `placement: 'left'` line from the configuration object in `plugin.js`. This now positions the dialog either above or below the chat panel. Since it resizes, this is much more flexible

## Testing
n/a