### PR TITLE
GDB-13099 fix guide continuing without namespace checkbox

### DIFF
--- a/plugins/guides/ttyg/ttyg-sparql-click-add-namespaces.js
+++ b/plugins/guides/ttyg/ttyg-sparql-click-add-namespaces.js
@@ -4,6 +4,7 @@ const step = {
   guideBlockName: 'ttyg-sparql-click-add-namespaces',
   getSteps: (options, services) => {
     const GuideUtils = services.GuideUtils;
+    const namespacesCheckbox = GuideUtils.getGuideElementSelector('add-missing-namespaces-input');
 
     return [
       {
@@ -16,7 +17,8 @@ const step = {
           ...options,
           url: 'ttyg',
           elementSelector: GuideUtils.getGuideElementSelector('add-missing-namespaces-option'),
-          onNextValidate: () => Promise.resolve(GuideUtils.isChecked(GuideUtils.getGuideElementSelector('add-missing-namespaces-input')))
+          clickableElementSelector: namespacesCheckbox,
+          onNextValidate: () => Promise.resolve(GuideUtils.isChecked(namespacesCheckbox))
         }
       }
     ];


### PR DESCRIPTION
## What
Fix the guide step for continuing without selecting the `Auto-add missing namespaces` checkbox

## Why
To ensure that users will proceed in the guide only after checking the checkbox

## How
Added the element to the  `clickableElementSelector` property to ensure the checkbox is clicked. Previously the guide continued when the clicked element is the surrounding parent

## Testing
n/a