### PR TITLE
GDB-13146: Can't return to dataset download step if skipped, requiring restart

### DIFF
--- a/plugins/guides/import/import-rdf-file.js
+++ b/plugins/guides/import/import-rdf-file.js
@@ -26,7 +26,9 @@ const step = {
 
     steps.push(...[
       {
-        guideBlockName: 'import-upload-rdf-file', options: {...options}
+        guideBlockName: 'import-upload-rdf-file', options: {
+          disablePreviousFlow: false,
+          ...options}
       },
       // This step is optional and will only appear if the file we want to upload has already been uploaded.
       // If the file is already uploaded, a confirmation dialog will be opened, and this step will display the confirm button of the dialog.


### PR DESCRIPTION
## What
Add a Previous button to the import-upload-rdf-file step.

## Why
In this step, the user must upload a file that was downloaded in the previous step. If they skip that step, they currently have to stop the guide and restart it. With the Previous button, the user can go back to the previous step to download the file without restarting the guide.

## How
Update the import-upload-rdf-file step to display a Previous button.