### PR TITLE
GDB-12984: update "click-main-menu" step

### DIFF
--- a/plugins/guides/main-menu/click-main-menu.js
+++ b/plugins/guides/main-menu/click-main-menu.js
@@ -43,6 +43,18 @@ const step = {
       helpInfo = 'view.autocomplete.helpInfo';
 
       break;
+
+    case 'connectors':
+      menuSelector = 'menu-setup';
+      menuTitle = 'menu.setup.label';
+      menuDialogClass = 'menu-setup-guide-dialog';
+      submenuSelector = 'sub-menu-connectors';
+      submenuTitle = 'menu.connectors.label';
+      submenuDialogClass = 'sub-menu-connectors-guide-dialog';
+      viewName = 'view.connector.management.title';
+      helpInfo = 'view.connector.management.helpInfo';
+
+      break;
     case 'visual-graph':
       menuSelector = 'menu-explore';
       menuTitle = 'menu.explore.label';


### PR DESCRIPTION
## What
Update the click-main-menu step with a new case for connectors view.

## Why
A previous MR added connector steps, but the update to the click-main-menu step was missed.

## How
Add the missing update to the click-main-menu step.