### PR TITLE
GDB-14190 make maximum links optional in visual graph config

### DIFF
--- a/docs/guides_visual-graph_visual-graph-config-create.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-create.js.html
@@ -402,20 +402,22 @@ const step = {
       options: {...options}
     });
 
-    steps.push({
-      guideBlockName: 'visual-graph-settings-click',
-      options: {...options}
-    });
+    if (options.linkLimit) {
+      steps.push({
+        guideBlockName: 'visual-graph-settings-click',
+        options: {...options}
+      });
 
-    steps.push({
-      guideBlockName: 'visual-graph-set-maximum-links',
-      options: {...options}
-    });
+      steps.push({
+        guideBlockName: 'visual-graph-set-maximum-links',
+        options: {...options}
+      });
 
-    steps.push({
-      guideBlockName: 'visual-graph-settings-save',
-      options: {...options}
-    });
+      steps.push({
+        guideBlockName: 'visual-graph-settings-save',
+        options: {...options}
+      });
+    }
 
     if (options.expandIri) {
       steps.push({

--- a/plugins/guides/visual-graph/visual-graph-config-create.js
+++ b/plugins/guides/visual-graph/visual-graph-config-create.js
@@ -311,20 +311,22 @@ const step = {
       options: {...options}
     });
 
-    steps.push({
-      guideBlockName: 'visual-graph-settings-click',
-      options: {...options}
-    });
+    if (options.linkLimit) {
+      steps.push({
+        guideBlockName: 'visual-graph-settings-click',
+        options: {...options}
+      });
 
-    steps.push({
-      guideBlockName: 'visual-graph-set-maximum-links',
-      options: {...options}
-    });
+      steps.push({
+        guideBlockName: 'visual-graph-set-maximum-links',
+        options: {...options}
+      });
 
-    steps.push({
-      guideBlockName: 'visual-graph-settings-save',
-      options: {...options}
-    });
+      steps.push({
+        guideBlockName: 'visual-graph-settings-save',
+        options: {...options}
+      });
+    }
 
     if (options.expandIri) {
       steps.push({


### PR DESCRIPTION
## What
Make the addition of maximum links in the visual graph configuration optional based on the `linkLimit` option.

## Why
To enhance flexibility in visual graph settings by allowing users to configure the maximum number of links as needed.

## How
Modified the `visual-graph-config-create.js` file to conditionally push steps related to maximum links based on the presence of the `linkLimit` option.

## Testing
n/a