### PR TITLE
Update Slack notification settings in release pipeline

### DIFF
--- a/JenkinsfileRelease
+++ b/JenkinsfileRelease
@@ -35,13 +35,13 @@ pipeline {
 
         booleanParam(
             name: 'NOTIFY_SLACK',
-            defaultValue: false,
+            defaultValue: true,
             description: 'Send Slack notification after successful build'
         )
 
         string(
             name: 'SLACK_CHANNEL',
-            defaultValue: '#workbench-plugins-test',
+            defaultValue: '#frontend-notifications',
             description: 'Slack channel for notification (only used if checkbox above is selected)'
         )
     }


### PR DESCRIPTION
## What
Changed the default Slack notification settings in the release pipeline to enable notifications and updated the default Slack channel.

## Why
This change ensures that notifications are sent to the appropriate Slack channel after successful builds, improving communication and visibility for the development team.

## How
- Set `NOTIFY_SLACK` default value to `true`
- Updated `SLACK_CHANNEL` default value to `#frontend-notifications`