### PR TITLE
GDB-14685 fix transparent copy button styling

### DIFF
--- a/docs/guides_core-steps_copy-text-element.js.html
+++ b/docs/guides_core-steps_copy-text-element.js.html
@@ -135,7 +135,7 @@ const step = {
 
     const copy = document.createElement('button');
     const copyToInputQueryButtonClass = 'guide-copy-to-input-query-button';
-    copy.className = `btn btn-sm btn-secondary ${copyToInputQueryButtonClass}`;
+    copy.className = `btn btn-sm btn-secondary editor-button ${copyToInputQueryButtonClass}`;
     copy.innerText = translate(this.translationBundle, COPY_TEXT);
 
     let stepHTMLElement;

--- a/plugins/guides/core-steps/copy-text-element.js
+++ b/plugins/guides/core-steps/copy-text-element.js
@@ -44,7 +44,7 @@ const step = {
 
     const copy = document.createElement('button');
     const copyToInputQueryButtonClass = 'guide-copy-to-input-query-button';
-    copy.className = `btn btn-sm btn-secondary ${copyToInputQueryButtonClass}`;
+    copy.className = `btn btn-sm btn-secondary editor-button ${copyToInputQueryButtonClass}`;
     copy.innerText = translate(this.translationBundle, COPY_TEXT);
 
     let stepHTMLElement;


### PR DESCRIPTION
## What
Fix transparent copy button styling in `copy-text-element.js`.

## Why
The button was transparent

## How
Added `editor-button` class, which will extend `btn-secondary` and override the background color to the provided one

## Testing
n/a