### PR TITLE
GDB-14708 fix visual graph expand step losing element

### DIFF
--- a/docs/guides_visual-graph_visual-graph-expand.js.html
+++ b/docs/guides_visual-graph_visual-graph-expand.js.html
@@ -168,7 +168,11 @@ const step = {
           },
           beforeShowPromise: () => {
             $route.reload();
-            return GuideUtils.deferredShow(50)()
+            // in some cases reloading starts after the defer and alpha drop. In such cases the step is shown, the page is
+            // reloaded and shepherd detaches from the element. Wait until the element is hidden to ensure the reload has
+            // started and then wait for the d3 alpha to drop, so we ensure the correct order
+            return GuideUtils.waitUntilHidden(elementSelector)
+              .then(() => GuideUtils.deferredShow(50)())
               .then(() => {
                 return GuideUtils.awaitAlphaDropD3(elementSelector, $rootScope)();
               });

--- a/docs/guides_visual-graph_visual-graph-zoom.js.html
+++ b/docs/guides_visual-graph_visual-graph-zoom.js.html
@@ -122,9 +122,9 @@ const step = {
       options: {
         ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
         content: translate(this.translationBundle, VISUAL_GRAPH_ZOOM_CONTENT),
+        url: 'graphs-visualizations',
         ...options,
         elementSelector,
-        url: 'graphs-visualizations',
         allowScroll: true
       }
     }];

--- a/plugins/guides/visual-graph/visual-graph-expand.js
+++ b/plugins/guides/visual-graph/visual-graph-expand.js
@@ -77,7 +77,11 @@ const step = {
           },
           beforeShowPromise: () => {
             $route.reload();
-            return GuideUtils.deferredShow(50)()
+            // in some cases reloading starts after the defer and alpha drop. In such cases the step is shown, the page is
+            // reloaded and shepherd detaches from the element. Wait until the element is hidden to ensure the reload has
+            // started and then wait for the d3 alpha to drop, so we ensure the correct order
+            return GuideUtils.waitUntilHidden(elementSelector)
+              .then(() => GuideUtils.deferredShow(50)())
               .then(() => {
                 return GuideUtils.awaitAlphaDropD3(elementSelector, $rootScope)();
               });

--- a/plugins/guides/visual-graph/visual-graph-zoom.js
+++ b/plugins/guides/visual-graph/visual-graph-zoom.js
@@ -31,9 +31,9 @@ const step = {
       options: {
         ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
         content: translate(this.translationBundle, VISUAL_GRAPH_ZOOM_CONTENT),
+        url: 'graphs-visualizations',
         ...options,
         elementSelector,
-        url: 'graphs-visualizations',
         allowScroll: true
       }
     }];


### PR DESCRIPTION
## What
Fix visual graph expand step losing element

## Why
The dialog was being displayed in the top left corner instead on the desired element. There was a race condition between reloading the page and the deferredShow. Sometimes the defer completes before the reload begins and the d3 alpha is already settled down so the step is displayed. The reload then starts and the step loses its target element

## How
Updated the `beforeShowPromise` function in `visual-graph-expand.js` to wait until the element is hidden before proceeding with the deferred show and awaiting the D3 alpha drop. Also, moved the url in `visual-graph-zoom.js` above the options to allow override.

## Testing
n/a