### PR TITLE
GDB-13829: Integration with Interactive Guides

### DIFF
--- a/docs/guides_sparql-editor_execute-sparql-query.js.html
+++ b/docs/guides_sparql-editor_execute-sparql-query.js.html
@@ -149,7 +149,6 @@ const step = {
   getSteps: function(options, services) {
     const translate = services.translate;
     const GuideUtils = services.GuideUtils;
-    const YasguiComponentDirectiveUtil = services.YasguiComponentDirectiveUtil;
     const toastr = services.toastr;
     const $translate = services.$translate;
     const $interpolate = services.$interpolate;
@@ -182,14 +181,14 @@ const step = {
         options: {
           query,
           queryExtraContent: queryDef.queryExtraContent,
-          beforeShowPromise: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
             .then(() => GuideUtils.deferredShow(500)())
             .catch((error) => {
               services.toastr.error(translate(this.translationBundle, UNEXPECTED_ERROR));
               throw error;
             }),
-          onNextValidate: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          onNextValidate: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then((yasgui) => yasgui.getQuery().then((query) => ({yasgui, queryFromEditor: query})))
             .then(({yasgui, queryFromEditor}) => {
               const editorQuery = GuideUtils.removeWhiteSpaces(queryFromEditor);
@@ -209,7 +208,7 @@ const step = {
             }),
           initPreviousStep: () => {
             if (index === 0) {
-              return YasguiComponentDirectiveUtil.setQuery(Utils.SPARQL_DIRECTIVE_SELECTOR, defaultQuery);
+              return services.YasguiComponentUtil.setQuery(Utils.SPARQL_DIRECTIVE_SELECTOR, defaultQuery);
             }
 
             const haveToReload = 'sparql' !== RoutingUtil.getCurrentRoute();
@@ -219,7 +218,7 @@ const step = {
             }
 
             return GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
-              .then(() => YasguiComponentDirectiveUtil.executeSparqlQuery('#query-editor', query));
+              .then(() => services.YasguiComponentUtil.executeSparqlQuery('#query-editor', query));
           },
           ...options
         }
@@ -237,7 +236,7 @@ const step = {
                   return Promise.resolve();
                 }
 
-                return YasguiComponentDirectiveUtil.executeSparqlQuery('#query-editor', query);
+                return services.YasguiComponentUtil.executeSparqlQuery('#query-editor', query);
               });
           },
           ...options
@@ -252,12 +251,12 @@ const step = {
               RoutingUtil.navigate('/sparql');
               return GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
                 .then(() => GuideUtils.deferredShow(500)())
-                .then(() => YasguiComponentDirectiveUtil.executeSparqlQuery('#query-editor', query));
+                .then(() => services.YasguiComponentUtil.executeSparqlQuery('#query-editor', query));
             }
 
             const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);
             return previousStep.options.initPreviousStep(services, previousStep.options.id)
-              .then(() => YasguiComponentDirectiveUtil.setQuery(Utils.SPARQL_DIRECTIVE_SELECTOR, query));
+              .then(() => services.YasguiComponentUtil.setQuery(Utils.SPARQL_DIRECTIVE_SELECTOR, query));
           },
           ...options
         }

--- a/docs/guides_sparql-editor_sparql-editor-run-button.js.html
+++ b/docs/guides_sparql-editor_sparql-editor-run-button.js.html
@@ -118,7 +118,6 @@ const step = {
   getSteps: function(options, services) {
     const translate = services.translate;
     const GuideUtils = services.GuideUtils;
-    const YasguiComponentDirectiveUtil = services.YasguiComponentDirectiveUtil;
     return [
       {
         guideBlockName: 'clickable-element',
@@ -128,7 +127,7 @@ const step = {
           url: 'sparql',
           elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_RUN_BUTTON_SELECTOR,
           class: 'yasgui-run-button',
-          onNextClick: (guide) => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          onNextClick: (guide) => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then((yasgui) => {
               yasgui.query();
               guide.next();

--- a/docs/guides_sparql-editor_sparql-editor.js.html
+++ b/docs/guides_sparql-editor_sparql-editor.js.html
@@ -128,7 +128,6 @@ const step = {
   getSteps: function(options, services) {
     const translate = services.translate;
     const GuideUtils = services.GuideUtils;
-    const YasguiComponentDirectiveUtil = services.YasguiComponentDirectiveUtil;
 
     const code = document.createElement('code');
     const copy = document.createElement('button');
@@ -136,7 +135,7 @@ const step = {
     copy.className = `btn btn-sm btn-secondary ${copyToEditorButtonClass}`;
     copy.innerText = translate(this.translationBundle, COPY_TO_EDITOR);
     const query = options.query;
-    const copyToEditorListener = Utils.createCopyToEditorListener(YasguiComponentDirectiveUtil, Utils.SPARQL_DIRECTIVE_SELECTOR, query);
+    const copyToEditorListener = Utils.createCopyToEditorListener(() => services.YasguiComponentUtil, Utils.SPARQL_DIRECTIVE_SELECTOR, query);
     code.innerText = query;
     const queryAsHtmlCodeElement = '&lt;div class="shepherd-code">' + code.outerHTML + copy.outerHTML + '&lt;/div>';
 
@@ -151,14 +150,14 @@ const step = {
           url: 'sparql',
           elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
           class: 'yasgui-query-editor',
-          beforeShowPromise: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
             .then(() => GuideUtils.deferredShow(500)())
             .catch((error) => {
               services.toastr.error(translate(this.translationBundle, UNEXPECTED_ERROR));
               throw error;
             }),
-          onNextValidate: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          onNextValidate: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then((yasgui) => yasgui.getQuery().then((query) => ({yasgui, queryFromEditor: query})))
             .then(({yasgui, _queryFromEditor}) => {
               yasgui.setQuery(query);

--- a/docs/guides_sparql-editor_sparql-explain-editor.js.html
+++ b/docs/guides_sparql-editor_sparql-explain-editor.js.html
@@ -122,7 +122,6 @@ const step = {
   getSteps: function(options, services) {
     const translate = services.translate;
     const GuideUtils = services.GuideUtils;
-    const YasguiComponentDirectiveUtil = services.YasguiComponentDirectiveUtil;
     return [
       {
         guideBlockName: 'input-element',
@@ -131,7 +130,7 @@ const step = {
           url: 'sparql',
           elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
           class: 'sparql-explain-editor',
-          beforeShowPromise: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
             .then(() => GuideUtils.deferredShow(500)())
             .catch((error) => {

--- a/docs/guides_utils.js.html
+++ b/docs/guides_utils.js.html
@@ -232,10 +232,10 @@ export const createDownloadClickHandler = (resourcePath, resourceFile, services)
   };
 };
 
-export const createCopyToEditorListener = (YasguiComponentDirectiveUtil, sparqlDirectiveSelector, query) => {
+export const createCopyToEditorListener = (getYasguiComponentUtil, sparqlDirectiveSelector, query) => {
   return (event) => {
     event.preventDefault();
-    YasguiComponentDirectiveUtil.setQuery(sparqlDirectiveSelector, query);
+    getYasguiComponentUtil().setQuery(sparqlDirectiveSelector, query);
   };
 };
 

--- a/plugins/guides/sparql-editor/execute-sparql-query.js
+++ b/plugins/guides/sparql-editor/execute-sparql-query.js
@@ -58,7 +58,6 @@ const step = {
   getSteps: function(options, services) {
     const translate = services.translate;
     const GuideUtils = services.GuideUtils;
-    const YasguiComponentDirectiveUtil = services.YasguiComponentDirectiveUtil;
     const toastr = services.toastr;
     const $translate = services.$translate;
     const $interpolate = services.$interpolate;
@@ -91,14 +90,14 @@ const step = {
         options: {
           query,
           queryExtraContent: queryDef.queryExtraContent,
-          beforeShowPromise: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
             .then(() => GuideUtils.deferredShow(500)())
             .catch((error) => {
               services.toastr.error(translate(this.translationBundle, UNEXPECTED_ERROR));
               throw error;
             }),
-          onNextValidate: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          onNextValidate: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then((yasgui) => yasgui.getQuery().then((query) => ({yasgui, queryFromEditor: query})))
             .then(({yasgui, queryFromEditor}) => {
               const editorQuery = GuideUtils.removeWhiteSpaces(queryFromEditor);
@@ -118,7 +117,7 @@ const step = {
             }),
           initPreviousStep: () => {
             if (index === 0) {
-              return YasguiComponentDirectiveUtil.setQuery(Utils.SPARQL_DIRECTIVE_SELECTOR, defaultQuery);
+              return services.YasguiComponentUtil.setQuery(Utils.SPARQL_DIRECTIVE_SELECTOR, defaultQuery);
             }
 
             const haveToReload = 'sparql' !== RoutingUtil.getCurrentRoute();
@@ -128,7 +127,7 @@ const step = {
             }
 
             return GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
-              .then(() => YasguiComponentDirectiveUtil.executeSparqlQuery('#query-editor', query));
+              .then(() => services.YasguiComponentUtil.executeSparqlQuery('#query-editor', query));
           },
           ...options
         }
@@ -146,7 +145,7 @@ const step = {
                   return Promise.resolve();
                 }
 
-                return YasguiComponentDirectiveUtil.executeSparqlQuery('#query-editor', query);
+                return services.YasguiComponentUtil.executeSparqlQuery('#query-editor', query);
               });
           },
           ...options
@@ -161,12 +160,12 @@ const step = {
               RoutingUtil.navigate('/sparql');
               return GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
                 .then(() => GuideUtils.deferredShow(500)())
-                .then(() => YasguiComponentDirectiveUtil.executeSparqlQuery('#query-editor', query));
+                .then(() => services.YasguiComponentUtil.executeSparqlQuery('#query-editor', query));
             }
 
             const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);
             return previousStep.options.initPreviousStep(services, previousStep.options.id)
-              .then(() => YasguiComponentDirectiveUtil.setQuery(Utils.SPARQL_DIRECTIVE_SELECTOR, query));
+              .then(() => services.YasguiComponentUtil.setQuery(Utils.SPARQL_DIRECTIVE_SELECTOR, query));
           },
           ...options
         }

--- a/plugins/guides/sparql-editor/sparql-editor-run-button.js
+++ b/plugins/guides/sparql-editor/sparql-editor-run-button.js
@@ -27,7 +27,6 @@ const step = {
   getSteps: function(options, services) {
     const translate = services.translate;
     const GuideUtils = services.GuideUtils;
-    const YasguiComponentDirectiveUtil = services.YasguiComponentDirectiveUtil;
     return [
       {
         guideBlockName: 'clickable-element',
@@ -37,7 +36,7 @@ const step = {
           url: 'sparql',
           elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_RUN_BUTTON_SELECTOR,
           class: 'yasgui-run-button',
-          onNextClick: (guide) => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          onNextClick: (guide) => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then((yasgui) => {
               yasgui.query();
               guide.next();

--- a/plugins/guides/sparql-editor/sparql-editor.js
+++ b/plugins/guides/sparql-editor/sparql-editor.js
@@ -37,7 +37,6 @@ const step = {
   getSteps: function(options, services) {
     const translate = services.translate;
     const GuideUtils = services.GuideUtils;
-    const YasguiComponentDirectiveUtil = services.YasguiComponentDirectiveUtil;
 
     const code = document.createElement('code');
     const copy = document.createElement('button');
@@ -45,7 +44,7 @@ const step = {
     copy.className = `btn btn-sm btn-secondary ${copyToEditorButtonClass}`;
     copy.innerText = translate(this.translationBundle, COPY_TO_EDITOR);
     const query = options.query;
-    const copyToEditorListener = Utils.createCopyToEditorListener(YasguiComponentDirectiveUtil, Utils.SPARQL_DIRECTIVE_SELECTOR, query);
+    const copyToEditorListener = Utils.createCopyToEditorListener(() => services.YasguiComponentUtil, Utils.SPARQL_DIRECTIVE_SELECTOR, query);
     code.innerText = query;
     const queryAsHtmlCodeElement = '<div class="shepherd-code">' + code.outerHTML + copy.outerHTML + '</div>';
 
@@ -60,14 +59,14 @@ const step = {
           url: 'sparql',
           elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
           class: 'yasgui-query-editor',
-          beforeShowPromise: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
             .then(() => GuideUtils.deferredShow(500)())
             .catch((error) => {
               services.toastr.error(translate(this.translationBundle, UNEXPECTED_ERROR));
               throw error;
             }),
-          onNextValidate: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          onNextValidate: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then((yasgui) => yasgui.getQuery().then((query) => ({yasgui, queryFromEditor: query})))
             .then(({yasgui, _queryFromEditor}) => {
               yasgui.setQuery(query);

--- a/plugins/guides/sparql-editor/sparql-explain-editor.js
+++ b/plugins/guides/sparql-editor/sparql-explain-editor.js
@@ -31,7 +31,6 @@ const step = {
   getSteps: function(options, services) {
     const translate = services.translate;
     const GuideUtils = services.GuideUtils;
-    const YasguiComponentDirectiveUtil = services.YasguiComponentDirectiveUtil;
     return [
       {
         guideBlockName: 'input-element',
@@ -40,7 +39,7 @@ const step = {
           url: 'sparql',
           elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
           class: 'sparql-explain-editor',
-          beforeShowPromise: () => YasguiComponentDirectiveUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
+          beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
             .then(() => GuideUtils.deferredShow(500)())
             .catch((error) => {

--- a/plugins/guides/utils.js
+++ b/plugins/guides/utils.js
@@ -141,10 +141,10 @@ export const createDownloadClickHandler = (resourcePath, resourceFile, services)
   };
 };
 
-export const createCopyToEditorListener = (YasguiComponentDirectiveUtil, sparqlDirectiveSelector, query) => {
+export const createCopyToEditorListener = (getYasguiComponentUtil, sparqlDirectiveSelector, query) => {
   return (event) => {
     event.preventDefault();
-    YasguiComponentDirectiveUtil.setQuery(sparqlDirectiveSelector, query);
+    getYasguiComponentUtil().setQuery(sparqlDirectiveSelector, query);
   };
 };
 


### PR DESCRIPTION
## What
The retrieval of the YasguiComponentUtil reference has been moved to the functions where it is used.

## Why
The reference was previously assigned to a variable when a guide step was created and then reused by functions executed later at runtime. This caused an issue because the reference can change dynamically during application execution.

For example, when a guide starts, it obtains a reference to YasguiComponentUtil from the legacy Workbench implementation. During the guide execution, navigation may occur to the new YASGUI implementation, which updates the utility reference. However, the guide step continues to use the previously stored reference to the legacy utility, causing functions to execute against the wrong implementation.

## How
- Removed the assignment of YasguiComponentUtil to a variable during step creation.
- Retrieved the utility reference directly within the functions executed at runtime, ensuring that the current utility reference is always used when a guide step is executed