### PR TITLE
GDB-13829: Fix guide step option spreading, GuideUtils caching, and undefined submenuLabel translation

### DIFF
--- a/docs/guides_autocomplete_autocomplete-enable-checkbox.js.html
+++ b/docs/guides_autocomplete_autocomplete-enable-checkbox.js.html
@@ -113,9 +113,7 @@ const CONTENT = 'guide.step_plugin.autocomplete-enable-checkbox.content';
 const step = {
   guideBlockName: 'autocomplete-enable-checkbox',
   getSteps: function(options, services) {
-    const GuideUtils = services.GuideUtils;
     const translate = services.translate;
-    const autocompleteCheckboxSelector = GuideUtils.getGuideElementSelector('autocompleteCheckbox');
     let checkboxElement;
     let autocompleteCheckboxClickEventHandler;
     return [
@@ -123,21 +121,21 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, CONTENT),
-          ...(options.title ? {} : {title: translate(this.translationBundle, DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           class: 'enable-autocomplete-checkbox',
           ...options,
           url: 'autocomplete',
-          elementSelector: autocompleteCheckboxSelector,
+          elementSelector: services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'),
           // Disable default behavior of service when element is clicked.
           advanceOn: undefined,
-          beforeShowPromise: () => GuideUtils.deferredShow(500)(),
+          beforeShowPromise: () => services.GuideUtils.deferredShow(500)(),
           show: (guide) => () => {
-            checkboxElement = document.querySelector(autocompleteCheckboxSelector);
+            checkboxElement = document.querySelector(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'));
             autocompleteCheckboxClickEventHandler = () => {
               // If autocomplete is enabled go to the next step.
-              GuideUtils.deferredShow(200)()
+              services.GuideUtils.deferredShow(200)()
                 .then(() => {
-                  if (GuideUtils.isGuideElementChecked('autocompleteCheckbox', ' input')) {
+                  if (services.GuideUtils.isGuideElementChecked('autocompleteCheckbox', ' input')) {
                     guide.next();
                   }
                 });
@@ -146,7 +144,7 @@ const step = {
             checkboxElement.addEventListener('mouseup', autocompleteCheckboxClickEventHandler);
           },
           onNextClick: (guide) => {
-            if (!GuideUtils.isGuideElementChecked('autocompleteCheckbox', ' input')) {
+            if (!services.GuideUtils.isGuideElementChecked('autocompleteCheckbox', ' input')) {
               checkboxElement.click();
             }
             guide.next();

--- a/docs/guides_autocomplete_autocomplete-focus-on-indexing-status.js.html
+++ b/docs/guides_autocomplete_autocomplete-focus-on-indexing-status.js.html
@@ -115,17 +115,16 @@ const CONTENT = 'guide.step_plugin.autocomplete-focus-on-indexing-status.content
 const step = {
   guideBlockName: 'autocomplete-focus-on-indexing-status',
   getSteps: function(options, services) {
-    const GuideUtils = services.GuideUtils;
     const translate = services.translate;
 
     return {
       guideBlockName: 'read-only-element',
       options: {
         content: translate(this.translationBundle, CONTENT),
-        ...(options.title ? {} : {title: translate(this.translationBundle, DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, DEFAULT_TITLE),
         ...options,
         url: 'autocomplete',
-        elementSelector: GuideUtils.getGuideElementSelector('autocompleteStatus'),
+        elementSelector: services.GuideUtils.getGuideElementSelector('autocompleteStatus'),
         class: 'autocomplete-status-info',
         canBePaused: false
       }

--- a/docs/guides_class-relationships_class-relationships-class-list-background-intro.js.html
+++ b/docs/guides_class-relationships_class-relationships-class-list-background-intro.js.html
@@ -124,7 +124,7 @@ const step = {
           placement: 'right',
           class: 'class-relationships-class-list-background-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/docs/guides_class-relationships_class-relationships-class-list-intro.js.html
+++ b/docs/guides_class-relationships_class-relationships-class-list-intro.js.html
@@ -124,7 +124,7 @@ const step = {
           placement: 'right',
           class: 'class-relationships-class-list-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/docs/guides_class-relationships_class-relationships-class-list-selection.js.html
+++ b/docs/guides_class-relationships_class-relationships-class-list-selection.js.html
@@ -123,7 +123,7 @@ const step = {
           placement: 'right',
           class: 'class-relationships-class-list-selection',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/docs/guides_class-relationships_class-relationships-diagram-intro.js.html
+++ b/docs/guides_class-relationships_class-relationships-diagram-intro.js.html
@@ -123,7 +123,7 @@ const step = {
           placement: 'left',
           class: 'class-relationships-diagram-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/docs/guides_class-relationships_class-relationships-digram-predicates-intro.js.html
+++ b/docs/guides_class-relationships_class-relationships-digram-predicates-intro.js.html
@@ -124,7 +124,7 @@ const step = {
           placement: 'left',
           class: 'class-relationships-digram-predicates-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/docs/guides_class-relationships_class-relationships-digram-thickness-intro.js.html
+++ b/docs/guides_class-relationships_class-relationships-digram-thickness-intro.js.html
@@ -124,7 +124,7 @@ const step = {
           placement: 'left',
           class: 'class-relationships-digram-thickness-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/docs/guides_class-relationships_class-relationships-intro.js.html
+++ b/docs/guides_class-relationships_class-relationships-intro.js.html
@@ -121,7 +121,7 @@ const step = {
           class: 'clas-hierarchy-intro',
           placement: 'left',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/docs/guides_class-relationships_class-relationships-named-graph-selection.js.html
+++ b/docs/guides_class-relationships_class-relationships-named-graph-selection.js.html
@@ -126,7 +126,7 @@ const step = {
           class: 'class-relationships-named-graph-selection',
           content: translate(this.translationBundle, CONTENT),
           scrollToHandler: () => GuideUtils.scrollIntoView(elementSelector, {block: 'center'}),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/docs/guides_connectors_connectors-array-subparameter-intro.js.html
+++ b/docs/guides_connectors_connectors-array-subparameter-intro.js.html
@@ -159,7 +159,7 @@ const step = {
     return [{
       guideBlockName: 'read-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-connector-intro',
         content: translate(this.translationBundle, SUBPARAMETER_INTRO),

--- a/docs/guides_connectors_connectors-close-view-sparql-query-dialog.js.html
+++ b/docs/guides_connectors_connectors-close-view-sparql-query-dialog.js.html
@@ -120,7 +120,7 @@ const step = {
     return [{
       guideBlockName: 'clickable-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-close-view-sparql-query-dialog',
         content: translate(this.translationBundle, CLOSE_VIEW_SPARQL_DIALOG),

--- a/docs/guides_connectors_connectors-connector-intro.js.html
+++ b/docs/guides_connectors_connectors-connector-intro.js.html
@@ -144,7 +144,7 @@ const step = {
     return [{
       guideBlockName: 'read-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-connector-intro',
         content: translate(this.translationBundle, CONNECTORS_INTRO_CONTENT),

--- a/docs/guides_connectors_connectors-expand-connector.js.html
+++ b/docs/guides_connectors_connectors-expand-connector.js.html
@@ -143,7 +143,7 @@ const step = {
     return [{
       guideBlockName: 'clickable-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-expand-connector',
         content: translate(this.translationBundle, EXPAND_CONNECTOR_CONTENT),

--- a/docs/guides_connectors_connectors-open-view-sparql-query-dialog.js.html
+++ b/docs/guides_connectors_connectors-open-view-sparql-query-dialog.js.html
@@ -145,7 +145,7 @@ const step = {
     return [{
       guideBlockName: 'clickable-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'open-view-sparql-query-dialog',
         content: translate(this.translationBundle, OPEN_VIEW_SPARQL_DIALOG),

--- a/docs/guides_connectors_connectors-parameter-fields-remaining-fields-intro.js.html
+++ b/docs/guides_connectors_connectors-parameter-fields-remaining-fields-intro.js.html
@@ -149,7 +149,7 @@ const step = {
 
     return [{
       guideBlockName: 'read-only-element', options: {
-        ...(options.title ?? {title: translate(step.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(step.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-remaining-fieldsets-intro',
         content: translate(step.translationBundle, REMAINING_FIELDS_INTRO),

--- a/docs/guides_connectors_connectors-parameter-intro.js.html
+++ b/docs/guides_connectors_connectors-parameter-intro.js.html
@@ -146,7 +146,7 @@ const step = {
     return [{
       guideBlockName: 'read-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-connector-intro',
         content: translate(this.translationBundle, PARAMETER_INTRO),

--- a/docs/guides_connectors_connectors-type-intro.js.html
+++ b/docs/guides_connectors_connectors-type-intro.js.html
@@ -139,7 +139,7 @@ const step = {
     return [{
       guideBlockName: 'read-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-connectors-intro',
         content: translate(this.translationBundle, CONNECTOR_TYPE_INTRO),

--- a/docs/guides_connectors_connectors-view-sparql-dialog-intro.js.html
+++ b/docs/guides_connectors_connectors-view-sparql-dialog-intro.js.html
@@ -120,7 +120,7 @@ const step = {
     return [{
       guideBlockName: 'scroll-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'left',
         class: 'connectors-view-sparql-dialog-intro',
         content: translate(this.translationBundle, VIEW_SPARQL_DIALOG),

--- a/docs/guides_connectors_lucene_connectors-expand-lucene.js.html
+++ b/docs/guides_connectors_lucene_connectors-expand-lucene.js.html
@@ -131,7 +131,7 @@ const step = {
       guideBlockName: 'connectors-expand-connector',
       options: {
         content: translate(this.translationBundle, LUCENE_EXPAND_CONTENT, {instanceName: options.instanceName}),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         connectorName: LUCENE_CONNECTOR_NAME,
         class: 'connectors-lucene-expand'

--- a/docs/guides_connectors_lucene_connectors-lucene-analyzer-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-analyzer-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, ANALYZER_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-analyzer-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-boost-properties-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-boost-properties-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, BOOST_PROPERTIES),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-boost-properties-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-detect-fields-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-detect-fields-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, DETECT_FIELDS),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-detect-fields-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-analyzed-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-analyzed-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, ANALYZED_INTRO_CONTENT),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-analyzed-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-datatype-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-datatype-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, DATATYPE_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-datatype-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-default-value-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-default-value-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, DEFAULT_VALUE_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-default-value-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-facet-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-facet-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, FACET_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-facet-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-field-name-transform-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-field-name-transform-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, TRANSFORM_INTRO_CONTENT),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-field-name-transform-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-ignore-invalid-values-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-ignore-invalid-values-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, INVALID_VALUES_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-ignore-invalid-values-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-indexed-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-indexed-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, INDEXED_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-indexed-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-intro.js.html
@@ -127,7 +127,7 @@ const step = {
       options: {
         content: translate(this.translationBundle, FIELD_INTRO_CONTENT),
         scrollOffset: GuideUtils.SCROLL_OFFSET.CENTER,
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-multivalued-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-multivalued-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, MULTIVALUED_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-multivalued-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-property-chain-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-property-chain-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, PROPERTY_CHAIN_INTRO_CONTENT),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-property-chain-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-remaining-fields-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-remaining-fields-intro.js.html
@@ -125,7 +125,7 @@ const step = {
       guideBlockName: 'connectors-parameter-fields-remaining-fields-intro',
       options: {
         content: translate(step.translationBundle, REMAINING_FIELDS_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-remaining-fields-intro',
         parameterName: 'fields',

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-stored-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-stored-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, STORED_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-stored-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-fields-value-filter-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-fields-value-filter-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, VALUE_FILTER_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-value-filter-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-import-file-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-import-file-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, IMPORT_FILE),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-import-file-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-import-graph-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-import-graph-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, IMPORT_GRAPH),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-import-graph-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-languages-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-languages-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, LANGUAGES_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-languages-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-open-view-sparql-query-dialog.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-open-view-sparql-query-dialog.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-open-view-sparql-query-dialog',
       options: {
         content: translate(this.translationBundle, OPEN_SPARQL),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-open-view-sparql-query-dialog',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-readonly-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-readonly-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, READONLY_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-readonly-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-skip-initial-indexing-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-skip-initial-indexing-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, SKIP_INITIAL_INDEXING),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-skip-initial-indexing-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-strip-markup-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-strip-markup-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, STRIP_MARKUP),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-strip-markup-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-type-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-type-intro.js.html
@@ -122,7 +122,7 @@ const step = {
       guideBlockName: 'connectors-type-intro',
       options: {
         content: translate(this.translationBundle, LUCENE_TYPE_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         connectorName: LUCENE_CONNECTOR_NAME,
         class: 'connectors-lucene-type-intro'

--- a/docs/guides_connectors_lucene_connectors-lucene-types-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-types-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, TYPES_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-types-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-value-filter-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-value-filter-intro.js.html
@@ -126,7 +126,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, VALUE_FILTER_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-value-filter-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/docs/guides_connectors_lucene_connectors-lucene-view-sparql-dialog-intro.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene-view-sparql-dialog-intro.js.html
@@ -121,7 +121,7 @@ const step = {
       guideBlockName: 'connectors-view-sparql-dialog-intro',
       options: {
         content: translate(this.translationBundle, VIEW_SPARQL_DIALOG),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-view-sparql-dialog-intro'
       }

--- a/docs/guides_connectors_lucene_connectors-lucene.js.html
+++ b/docs/guides_connectors_lucene_connectors-lucene.js.html
@@ -131,7 +131,7 @@ const step = {
       guideBlockName: 'connectors-connector-intro',
       options: {
         content: translate(this.translationBundle, LUCENE_CONTENT, {instanceName: options.instanceName}),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         connectorName: LUCENE_CONNECTOR_NAME,
         class: 'connectors-lucene'

--- a/docs/guides_import_import-click-on-import-button.js.html
+++ b/docs/guides_import_import-click-on-import-button.js.html
@@ -122,7 +122,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(step.translationBundle, CONTENT),
-          ...(options.title ? {} : {title: translate(step.translationBundle, DEFAULT_TITLE)}),
+          title: translate(step.translationBundle, DEFAULT_TITLE),
           placement: 'top',
           class: 'import-settings-import-file-button',
           ...options,

--- a/docs/guides_import_import-confirm-duplicate-files.js.html
+++ b/docs/guides_import_import-confirm-duplicate-files.js.html
@@ -120,7 +120,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(step.translationBundle, CONTENT),
-          ...(options.title ? {} : {title: translate(step.translationBundle, DEFAULT_TITLE)}),
+          title: translate(step.translationBundle, DEFAULT_TITLE),
           placement: 'bottom',
           class: 'import-file-button',
           ...options,

--- a/docs/guides_import_import-show-progress.js.html
+++ b/docs/guides_import_import-show-progress.js.html
@@ -124,7 +124,7 @@ const step = {
         guideBlockName: 'read-only-element',
         options: {
           content: translate(step.translationBundle, CONTENT),
-          ...(options.title ? {} : {title: translate(step.translationBundle, DEFAULT_TITLE)}),
+          title: translate(step.translationBundle, DEFAULT_TITLE),
           class: 'import-status-info',
           ...options,
           url: 'import',

--- a/docs/guides_import_import-upload-rdf-file.js.html
+++ b/docs/guides_import_import-upload-rdf-file.js.html
@@ -133,7 +133,7 @@ const step = {
         options: {
           content: translate(step.translationBundle, CONTENT, {resourceFile: options.resourceFile}),
           class: 'upload-rdf-file-button',
-          ...(options.title ? {} : {title: translate(step.translationBundle, DEFAULT_TITLE)}),
+          title: translate(step.translationBundle, DEFAULT_TITLE),
           ...options,
           url: 'import',
           elementSelector: GuideUtils.getGuideElementSelector('uploadRdfFileButton'),

--- a/docs/guides_main-menu_click-main-menu.js.html
+++ b/docs/guides_main-menu_click-main-menu.js.html
@@ -182,7 +182,6 @@ const step = {
   guideBlockName: 'click-main-menu',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
     const steps = [];
 
     let menuSelector;
@@ -345,7 +344,7 @@ const step = {
     }
 
     const menuLabel = translate(this.translationBundle, menuTitle);
-    const elementSelector = GuideUtils.getGuideElementSelector(menuSelector);
+    const elementSelector = services.GuideUtils.getGuideElementSelector(menuSelector);
     // Main menu element
     steps.push({
       guideBlockName: 'clickable-element',
@@ -354,9 +353,9 @@ const step = {
         class: menuDialogClass,
         elementSelector,
         beforeShowPromise: () => {
-          if (!!submenuSelector &amp;&amp; GuideUtils.isGuideElementVisible(submenuSelector)) {
+          if (!!submenuSelector &amp;&amp; services.GuideUtils.isGuideElementVisible(submenuSelector)) {
             return new Promise((resolve) => {
-              GuideUtils.clickOnGuideElement(menuSelector, mainMenuClickElementPostSelector)();
+              services.GuideUtils.clickOnGuideElement(menuSelector, mainMenuClickElementPostSelector)();
               // Needed to wait the layout to complete, before painting, thus avoiding ResizeObserver loop error
               setTimeout(resolve, 500);
             });
@@ -364,8 +363,8 @@ const step = {
           return Promise.resolve();
         },
 
-        onNextClick: GuideUtils.clickOnGuideElement(menuSelector, mainMenuClickElementPostSelector),
-        scrollToHandler: () => GuideUtils.scrollIntoView(elementSelector, {block: 'center'}),
+        onNextClick: services.GuideUtils.clickOnGuideElement(menuSelector, mainMenuClickElementPostSelector),
+        scrollToHandler: () => services.GuideUtils.scrollIntoView(elementSelector, {block: 'center'}),
         initPreviousStep: (services, stepId) => {
           const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);
           if (previousStep) {
@@ -378,9 +377,9 @@ const step = {
       }
     });
 
-    const submenuLabel = translate(this.translationBundle, submenuTitle);
     if (submenuSelector) {
-      const elementSubmenuSelector = GuideUtils.getGuideElementSelector(submenuSelector);
+      const submenuLabel = translate(this.translationBundle, submenuTitle);
+      const elementSubmenuSelector = services.GuideUtils.getGuideElementSelector(submenuSelector);
       steps.push({
         guideBlockName: 'clickable-element',
         options: {
@@ -389,8 +388,8 @@ const step = {
           elementSelector: elementSubmenuSelector,
           placement: 'right',
           canBePaused: false,
-          onNextClick: GuideUtils.clickOnGuideElement(submenuSelector, ' a'),
-          scrollToHandler: () => GuideUtils.scrollIntoView(elementSubmenuSelector, {block: 'center'}),
+          onNextClick: services.GuideUtils.clickOnGuideElement(submenuSelector, ' a'),
+          scrollToHandler: () => services.GuideUtils.scrollIntoView(elementSubmenuSelector, {block: 'center'}),
           initPreviousStep: (services, stepId) => {
             const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);
             if (previousStep) {

--- a/docs/guides_rdf-rank_rdf-rank-compute-fill.js.html
+++ b/docs/guides_rdf-rank_rdf-rank-compute-fill.js.html
@@ -124,7 +124,7 @@ const step = {
           url: 'rdfrank',
           content: translate(this.translationBundle, COMPUTE_FILL),
           elementSelector: computeRDFRankButtonSelector,
-          ...(options.title ?? {title: translate(this.translationBundle, RDF_RANK_TITLE)}),
+          title: translate(this.translationBundle, RDF_RANK_TITLE),
           onNextClick: GuideUtils.clickOnElement( computeRDFRankButtonSelector),
           ...options
         }

--- a/docs/guides_repositories_repositories-select-repository.js.html
+++ b/docs/guides_repositories_repositories-select-repository.js.html
@@ -131,7 +131,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, SELECT_REPO_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_DEFAULT_TITLE),
           url: 'repository',
           elementSelector: selectRepositoryButtonWrapperSelector,
           class: 'repositories-select-repository',

--- a/docs/guides_repository_repositories-create-graphdb.js.html
+++ b/docs/guides_repository_repositories-create-graphdb.js.html
@@ -121,7 +121,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, GRAPHDB_REPOSITORY_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'create-gdb-repository',
           ...options,
           url: 'repository/create',

--- a/docs/guides_repository_repositories-create-repository.js.html
+++ b/docs/guides_repository_repositories-create-repository.js.html
@@ -121,7 +121,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, CREATE_REPO_BUTTON),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'create-repository',
           ...options,
           url: 'repository',

--- a/docs/guides_repository_repositories-enable-fts.js.html
+++ b/docs/guides_repository_repositories-enable-fts.js.html
@@ -122,7 +122,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, ENABLE_FTS_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'gdb-repository-enable-fts',
           extraContent: translate(this.translationBundle, EXTRA_CONTENT),
           extraContentClass: 'alert alert-help text-left',

--- a/docs/guides_repository_repositories-id-input.js.html
+++ b/docs/guides_repository_repositories-id-input.js.html
@@ -123,7 +123,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, REPOSITORY_ID_CONTENT, {repositoryId: options.repositoryId}),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'gdb-repository-id-input',
           ...options,
           url: 'repository/create/graphdb',

--- a/docs/guides_repository_repositories-ruleset-dropdown.js.html
+++ b/docs/guides_repository_repositories-ruleset-dropdown.js.html
@@ -126,7 +126,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, DROPDOWN_CONTENT, {rulesetName: options.rulesetName}),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'gdb-repository-ruleset-select',
           ...options,
           url: 'repository/create/graphdb',

--- a/docs/guides_repository_repositories-save.js.html
+++ b/docs/guides_repository_repositories-save.js.html
@@ -122,7 +122,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, SAVE_BUTTON),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'create-repository-button',
           ...options,
           url: 'repository/create/graphdb',

--- a/docs/guides_resource_resource-search-autocomplete-item.js.html
+++ b/docs/guides_resource_resource-search-autocomplete-item.js.html
@@ -127,7 +127,7 @@ const step = {
       {
         guideBlockName: 'clickable-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, RESOURCE_SEARCH_AUTOCOMPLETE_ITEM_TITLE)}),
+          title: translate(this.translationBundle, RESOURCE_SEARCH_AUTOCOMPLETE_ITEM_TITLE),
           content: translate(this.translationBundle, RESOURCE_SEARCH_AUTOCOMPLETE_ITEM_CONTENT, {iri: options.iri}),
           elementSelector: GuideUtils.getGuideElementSelector(`autocomplete-${options.iri}`),
           onNextClick: (guide, step) => GuideUtils.waitFor(step.elementSelector, 3).then(() => $(step.elementSelector).trigger('click')),

--- a/docs/guides_resource_resource-search-rdf.js.html
+++ b/docs/guides_resource_resource-search-rdf.js.html
@@ -131,7 +131,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, RESOURCE_SEARCH_RDF_CONTENT, {searchTerm}),
-          ...(options.title ?? {title: translate(this.translationBundle, RESOURCE_SEARCH_RDF_TITLE)}),
+          title: translate(this.translationBundle, RESOURCE_SEARCH_RDF_TITLE),
           ...options,
           elementSelector,
           onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(elementSelector, searchTerm))

--- a/docs/guides_similarity-index_similarity-click-link.js.html
+++ b/docs/guides_similarity-index_similarity-click-link.js.html
@@ -121,7 +121,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, CREATE_INDEX),
-          ...(options.title ?? {title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT)}),
+          title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
           class: 'similarity-index',
           disableNextFlow: true,
           ...options,

--- a/docs/guides_similarity-index_similarity-click-to-create.js.html
+++ b/docs/guides_similarity-index_similarity-click-to-create.js.html
@@ -121,7 +121,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, CREATE_INDEX),
-          ...(options.title ?? {title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT)}),
+          title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
           class: 'create-similarity-index',
           disablePreviousFlow: false,
           disableNextFlow: true,

--- a/docs/guides_similarity-index_similarity-hold-and-wait-until-shown.js.html
+++ b/docs/guides_similarity-index_similarity-hold-and-wait-until-shown.js.html
@@ -119,7 +119,7 @@ const step = {
       {
         guideBlockName: 'hold-and-wait-until-shown',
         options: {
-          title: options.title ?? translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
+          title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
           content: translate(this.translationBundle, WAIT_FOR_INDEX),
           class: 'wait-for-index',
           ...options,

--- a/docs/guides_similarity-index_similarity-type-index-name.js.html
+++ b/docs/guides_similarity-index_similarity-type-index-name.js.html
@@ -121,7 +121,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, INPUT_INDEX_NAME),
-          ...(options.title ?? {title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT)}),
+          title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
           class: 'similarity-index-name-input',
           ...options,
           url: 'similarity/index/create',

--- a/docs/guides_similarity-index_similarity-view-created-index.js.html
+++ b/docs/guides_similarity-index_similarity-view-created-index.js.html
@@ -147,7 +147,7 @@ const step = {
           content,
           url: 'similarity',
           class: 'view-created-index',
-          ...(options.title ?? {title: CREATE_SIMILARITY_INDEX_DEFAULT}),
+          title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
           ...options,
           elementSelector
         }

--- a/docs/guides_sparql-editor_execute-sparql-query.js.html
+++ b/docs/guides_sparql-editor_execute-sparql-query.js.html
@@ -148,11 +148,7 @@ const step = {
   guideBlockName: 'execute-sparql-query',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
-    const toastr = services.toastr;
-    const $translate = services.$translate;
-    const $interpolate = services.$interpolate;
-    const RoutingUtil = services.RoutingUtil;
+
     options.mainAction = 'execute-sparql-query';
     options.title = options.title ?? translate(this.translationBundle, SPARQL_EDITOR_TITLE);
 
@@ -182,8 +178,8 @@ const step = {
           query,
           queryExtraContent: queryDef.queryExtraContent,
           beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
-            .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
-            .then(() => GuideUtils.deferredShow(500)())
+            .then(() => services.GuideUtils.waitFor(services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
+            .then(() => services.GuideUtils.deferredShow(500)())
             .catch((error) => {
               services.toastr.error(translate(this.translationBundle, UNEXPECTED_ERROR));
               throw error;
@@ -191,14 +187,14 @@ const step = {
           onNextValidate: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then((yasgui) => yasgui.getQuery().then((query) => ({yasgui, queryFromEditor: query})))
             .then(({yasgui, queryFromEditor}) => {
-              const editorQuery = GuideUtils.removeWhiteSpaces(queryFromEditor);
-              const stepQuery = GuideUtils.removeWhiteSpaces(query);
+              const editorQuery = services.GuideUtils.removeWhiteSpaces(queryFromEditor);
+              const stepQuery = services.GuideUtils.removeWhiteSpaces(query);
               if (editorQuery !== stepQuery) {
                 if (editorQuery === 'select*where{?s?p?o.}limit100' || overwriteQuery) {
                   // The query is the default query OR we previously overwrote it => we can overwrite it
                   yasgui.setQuery(query);
                 } else {
-                  GuideUtils.noNextErrorToast(toastr, $translate, $interpolate,
+                  services.GuideUtils.noNextErrorToast(services.toastr, services.$translate, services.$interpolate,
                     QUERY_NOT_SAME_ERROR, options);
                   return false;
                 }
@@ -211,13 +207,13 @@ const step = {
               return services.YasguiComponentUtil.setQuery(Utils.SPARQL_DIRECTIVE_SELECTOR, defaultQuery);
             }
 
-            const haveToReload = 'sparql' !== RoutingUtil.getCurrentRoute();
+            const haveToReload = 'sparql' !== services.RoutingUtil.getCurrentRoute();
 
             if (haveToReload) {
-              RoutingUtil.navigate('/sparql');
+              services.RoutingUtil.navigate('/sparql');
             }
 
-            return GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
+            return services.GuideUtils.waitFor(services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
               .then(() => services.YasguiComponentUtil.executeSparqlQuery('#query-editor', query));
           },
           ...options
@@ -247,10 +243,10 @@ const step = {
         options: {
           extraContent: queryDef.resultExtraContent,
           initPreviousStep: (services, stepId) => {
-            if ('sparql' !== RoutingUtil.getCurrentRoute()) {
-              RoutingUtil.navigate('/sparql');
-              return GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
-                .then(() => GuideUtils.deferredShow(500)())
+            if ('sparql' !== services.RoutingUtil.getCurrentRoute()) {
+              services.RoutingUtil.navigate('/sparql');
+              return services.GuideUtils.waitFor(services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
+                .then(() => services.GuideUtils.deferredShow(500)())
                 .then(() => services.YasguiComponentUtil.executeSparqlQuery('#query-editor', query));
             }
 

--- a/docs/guides_sparql-editor_sparql-editor-expand-results-over-owl.js.html
+++ b/docs/guides_sparql-editor_sparql-editor-expand-results-over-owl.js.html
@@ -119,7 +119,7 @@ const step = {
       {
         guideBlockName: 'read-only-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           content: translate(this.translationBundle, EXPAND_RESULTS_CONTENT),
           url: 'sparql',
           elementSelector: '.yasqe_expandResultsButton',

--- a/docs/guides_sparql-editor_sparql-editor-include-inferred-data.js.html
+++ b/docs/guides_sparql-editor_sparql-editor-include-inferred-data.js.html
@@ -119,7 +119,7 @@ const step = {
       {
         guideBlockName: 'read-only-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           content: translate(this.translationBundle, INCLUDE_INFERRED_CONTENT),
           url: 'sparql',
           elementSelector: '.yasqe_inferStatementsButton',

--- a/docs/guides_sparql-editor_sparql-editor-run-button.js.html
+++ b/docs/guides_sparql-editor_sparql-editor-run-button.js.html
@@ -117,22 +117,22 @@ const step = {
   guideBlockName: 'sparql-editor-run-button',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
+
     return [
       {
         guideBlockName: 'clickable-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           content: translate(this.translationBundle, RUN_QUERY),
           url: 'sparql',
-          elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_RUN_BUTTON_SELECTOR,
+          elementSelector: services.GuideUtils.CSS_SELECTORS.SPARQL_RUN_BUTTON_SELECTOR,
           class: 'yasgui-run-button',
           onNextClick: (guide) => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then((yasgui) => {
               yasgui.query();
               guide.next();
             }),
-          scrollToHandler: GuideUtils.scrollToTop,
+          scrollToHandler: services.GuideUtils.scrollToTop,
           ...options
         }
       }

--- a/docs/guides_sparql-editor_sparql-editor.js.html
+++ b/docs/guides_sparql-editor_sparql-editor.js.html
@@ -127,7 +127,6 @@ const step = {
   guideBlockName: 'sparql-editor',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
 
     const code = document.createElement('code');
     const copy = document.createElement('button');
@@ -145,14 +144,14 @@ const step = {
       {
         guideBlockName: 'input-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           content: translate(this.translationBundle, QUERY_EDITOR_CONTENT, {queryAsHtmlCodeElement}),
           url: 'sparql',
-          elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
+          elementSelector: services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
           class: 'yasgui-query-editor',
           beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
-            .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
-            .then(() => GuideUtils.deferredShow(500)())
+            .then(() => services.GuideUtils.waitFor(services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
+            .then(() => services.GuideUtils.deferredShow(500)())
             .catch((error) => {
               services.toastr.error(translate(this.translationBundle, UNEXPECTED_ERROR));
               throw error;
@@ -163,7 +162,7 @@ const step = {
               yasgui.setQuery(query);
               return true;
             }),
-          scrollToHandler: GuideUtils.scrollToTop,
+          scrollToHandler: services.GuideUtils.scrollToTop,
           extraContent: options.queryExtraContent,
           show: (_guide) => () => {
             stepHTMLElement = _guide.currentStep.el.querySelector(`.${copyToEditorButtonClass}`);

--- a/docs/guides_sparql-editor_sparql-explain-editor.js.html
+++ b/docs/guides_sparql-editor_sparql-explain-editor.js.html
@@ -121,23 +121,22 @@ const step = {
   guideBlockName: 'sparql-explain-editor',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
     return [
       {
         guideBlockName: 'input-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           url: 'sparql',
-          elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
+          elementSelector: services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
           class: 'sparql-explain-editor',
           beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
-            .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
-            .then(() => GuideUtils.deferredShow(500)())
+            .then(() => services.GuideUtils.waitFor(services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
+            .then(() => services.GuideUtils.deferredShow(500)())
             .catch((error) => {
               services.toastr.error(translate(this.translationBundle, UNEXPECTED_ERROR));
               throw error;
             }),
-          scrollToHandler: GuideUtils.scrollToTop,
+          scrollToHandler: services.GuideUtils.scrollToTop,
           extraContent: options.extraContent,
           ...options
         }

--- a/docs/guides_sparql-editor_sparql-results-click-on-iri.js.html
+++ b/docs/guides_sparql-editor_sparql-results-click-on-iri.js.html
@@ -121,21 +121,20 @@ const step = {
   guideBlockName: 'sparql-results-click-on-iri',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
     return [
       {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, CLICK_ON_IRI, {iriLabel: options.iriLabel}),
           placement: 'top',
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           ...options,
-          scrollToHandler: GuideUtils.scrollToTop,
-          elementSelector: GuideUtils.getSparqlResultsSelectorForIri(options.iri),
+          scrollToHandler: services.GuideUtils.scrollToTop,
+          elementSelector: services.GuideUtils.getSparqlResultsSelectorForIri(options.iri),
           class: 'table-graph-instance',
-          url: '/sparql',
+          url: 'sparql',
           onNextClick: (guide, step) => {
-            GuideUtils.waitFor(step.elementSelector, 3)
+            services.GuideUtils.waitFor(step.elementSelector, 3)
               .then(() => document.querySelector(step.elementSelector).click());
           }
         }

--- a/docs/guides_sparql-editor_sparql-results-explain.js.html
+++ b/docs/guides_sparql-editor_sparql-results-explain.js.html
@@ -115,19 +115,18 @@ const step = {
   guideBlockName: 'sparql-results-explain',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
     return [
       {
         guideBlockName: 'read-only-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           content: translate(this.translationBundle, EXPLAIN_CONTENT),
           url: 'sparql',
           placement: 'top',
-          elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_RESULTS_SELECTOR,
+          elementSelector: services.GuideUtils.CSS_SELECTORS.SPARQL_RESULTS_SELECTOR,
           class: 'yasgui-query-results',
           fileName: options.fileName,
-          scrollToHandler: GuideUtils.scrollToTop,
+          scrollToHandler: services.GuideUtils.scrollToTop,
           extraContent: options.resultExtraContent,
           canBePaused: false,
           ...options

--- a/docs/guides_sparql-editor_sparql-results-visual-button.js.html
+++ b/docs/guides_sparql-editor_sparql-results-visual-button.js.html
@@ -115,18 +115,17 @@ const step = {
   guideBlockName: 'sparql-results-visual-button',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
     return [
       {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, SPARQL_RESULT_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           url: 'sparql',
-          elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_VISUAL_BUTTON_SELECTOR,
+          elementSelector: services.GuideUtils.CSS_SELECTORS.SPARQL_VISUAL_BUTTON_SELECTOR,
           class: 'visual-sparql-results-button',
-          scrollToHandler: GuideUtils.scrollToTop,
-          onNextClick: () => GuideUtils.clickOnElement(GuideUtils.CSS_SELECTORS.SPARQL_VISUAL_BUTTON_SELECTOR)(),
+          scrollToHandler: services.GuideUtils.scrollToTop,
+          onNextClick: () => services.GuideUtils.clickOnElement(services.GuideUtils.CSS_SELECTORS.SPARQL_VISUAL_BUTTON_SELECTOR)(),
           ...options
         }
       }

--- a/docs/guides_ttyg_configure-agent-additional-instructions.js.html
+++ b/docs/guides_ttyg_configure-agent-additional-instructions.js.html
@@ -127,7 +127,7 @@ const step = {
         guideBlockName: 'copy-text-element',
         options: {
           extraContent: translate(this.translationBundle, CONFIGURE_USER_INSTRUCTIONS),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
           class: 'input-user-instructions',
           disablePreviousFlow: false,
           text: options.userInstructions,

--- a/docs/guides_ttyg_configure-agent-type-agent-name.js.html
+++ b/docs/guides_ttyg_configure-agent-type-agent-name.js.html
@@ -125,7 +125,7 @@ const step = {
           content: translate(this.translationBundle, CONFIGURE_AGENT_NAME),
           class: 'input-agent-name',
           disablePreviousFlow: false,
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
           ...options,
           url: 'ttyg',
           beforeShowPromise: () => GuideUtils.waitFor(GuideUtils.getGuideElementSelector('agent-form'), 5)

--- a/docs/guides_ttyg_configure-agent-type-model-name.js.html
+++ b/docs/guides_ttyg_configure-agent-type-model-name.js.html
@@ -128,7 +128,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, CONFIGURE_AGENT_MODEL, {model: options.model}),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
           class: 'input-model',
           disablePreviousFlow: false,
           ...options,

--- a/docs/guides_ttyg_configure-autocomplete-iri-discovery.js.html
+++ b/docs/guides_ttyg_configure-autocomplete-iri-discovery.js.html
@@ -138,7 +138,7 @@ const step = {
       options: {
         content,
         class: 'toggle-autocomplete-iri-discovery',
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         ...options,
         url: 'ttyg',
         elementSelector: GuideUtils.getGuideElementSelector('autocomplete-iri-discovery'),

--- a/docs/guides_ttyg_configure-iri-discovery-search.js.html
+++ b/docs/guides_ttyg_configure-iri-discovery-search.js.html
@@ -139,7 +139,7 @@ const step = {
       options: {
         content,
         class: 'toggle-iri-discovery-search',
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         ...options,
         url: 'ttyg',
         elementSelector,

--- a/docs/guides_ttyg_configure-temperature.js.html
+++ b/docs/guides_ttyg_configure-temperature.js.html
@@ -135,7 +135,7 @@ const step = {
         class: 'configure-temperature',
         content: translate(this.translationBundle, CONFIGURE_TEMPERATURE_INFO, {temperature: options.temperature}),
         onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(inputSelector, options.temperature)),
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         ...options
       }
     };

--- a/docs/guides_ttyg_configure-top-p.js.html
+++ b/docs/guides_ttyg_configure-top-p.js.html
@@ -135,7 +135,7 @@ const step = {
         class: 'configure-top-p',
         content: translate(this.translationBundle, CONFIGURE_TOP_P, {topP: options.topP}),
         onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(inputSelector, options.topP)),
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         ...options
       }
     };

--- a/docs/guides_ttyg_set-context-window-size.js.html
+++ b/docs/guides_ttyg_set-context-window-size.js.html
@@ -134,7 +134,7 @@ const step = {
         class: 'set-context-window-size',
         content: translate(this.translationBundle, SET_CONTEXT_WINDOW_SIZE, {contextSize: options.contextSize}),
         onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(inputSelector, options.contextSize)),
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         ...options
       }
     };

--- a/docs/guides_ttyg_set-max-iris-per-call.js.html
+++ b/docs/guides_ttyg_set-max-iris-per-call.js.html
@@ -129,7 +129,7 @@ const step = {
       guideBlockName: 'input-element',
       options: {
         content: translate(this.translationBundle, SET_MAX_IRIS_PER_CALL, {maxIrisPerCall}),
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         class: 'set-max-iris-per-call',
         ...options,
         url: 'ttyg',

--- a/docs/guides_ttyg_set-max-triples-per-call.js.html
+++ b/docs/guides_ttyg_set-max-triples-per-call.js.html
@@ -127,7 +127,7 @@ const step = {
       guideBlockName: 'input-element',
       options: {
         content: translate(this.translationBundle, SET_MAX_TRIPLES_PER_CALL, {maxTriplesPerCall: options.maxTriplesPerCall}),
-        ...(options.title ?? {title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE),
         class: 'toggle-fts-search',
         ...options,
         url: 'ttyg',

--- a/docs/guides_ttyg_sparql-search-method-type-graph-name.js.html
+++ b/docs/guides_ttyg_sparql-search-method-type-graph-name.js.html
@@ -128,7 +128,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, TYPE_ONTLOGY_GRAPH, {ontologyGraph: options.ontologyGraph}),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           class: 'input-ontology-graph-name',
           ...options,
           url: 'ttyg',

--- a/docs/guides_ttyg_ttyg-click-to-edit-selected-agent.js.html
+++ b/docs/guides_ttyg_ttyg-click-to-edit-selected-agent.js.html
@@ -122,7 +122,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, EDIT_TTYG_AGENT),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE),
           class: 'edit-agent-btn',
           disableNextFlow: true,
           ...options,

--- a/docs/guides_ttyg_ttyg-edit-agent-click-to-save.js.html
+++ b/docs/guides_ttyg_ttyg-edit-agent-click-to-save.js.html
@@ -122,7 +122,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, SAVE_AGENT),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE),
           class: 'save-agent',
           disablePreviousFlow: false,
           disableNextFlow: true,

--- a/docs/guides_ttyg_ttyg-edit-agent-intro-message.js.html
+++ b/docs/guides_ttyg_ttyg-edit-agent-intro-message.js.html
@@ -122,7 +122,7 @@ const step = {
         guideBlockName: 'info-message',
         options: {
           content: translate(this.translationBundle, EDIT_TTYG_AGENT),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE),
           skipPoint: true,
           skipButtonLabel: translate(this.translationBundle, SKIP_SECTION),
           ...options

--- a/docs/guides_ttyg_ttyg-enabling-sparql-info-message.js.html
+++ b/docs/guides_ttyg_ttyg-enabling-sparql-info-message.js.html
@@ -121,7 +121,7 @@ const step = {
         guideBlockName: 'info-message',
         options: {
           content: translate(this.translationBundle, SEARCH_METHOD_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           class: 'info-sparql-search',
           ...options,
           url: 'ttyg'

--- a/docs/guides_ttyg_ttyg-fts-method-disable.js.html
+++ b/docs/guides_ttyg_ttyg-fts-method-disable.js.html
@@ -124,7 +124,7 @@ const step = {
         guideBlockName: 'toggle-element',
         options: {
           content: translate(this.translationBundle, DISABLE_TOGGLE),
-          ...(options.title ?? {title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE),
           class: 'toggle-fts-search',
           ...options,
           disable: true,

--- a/docs/guides_ttyg_ttyg-fts-method-enable.js.html
+++ b/docs/guides_ttyg_ttyg-fts-method-enable.js.html
@@ -124,7 +124,7 @@ const step = {
         guideBlockName: 'toggle-element',
         options: {
           content: translate(this.translationBundle, ENABLE_TOGGLE),
-          ...(options.title ?? {title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE),
           class: 'toggle-fts-search',
           ...options,
           url: 'ttyg',

--- a/docs/guides_ttyg_ttyg-fts-method-info.js.html
+++ b/docs/guides_ttyg_ttyg-fts-method-info.js.html
@@ -123,7 +123,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, FTS_SEARCH_CONTENT),
           // If mainAction is set the title will be set automatically
-          ...(options.title ?? {title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE),
           class: 'info-fts-search',
           ...options,
           url: 'ttyg'

--- a/docs/guides_ttyg_ttyg-select-agent-check-for-missing-repository-cancel.js.html
+++ b/docs/guides_ttyg_ttyg-select-agent-check-for-missing-repository-cancel.js.html
@@ -141,7 +141,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, MISSING_REPOSITORY),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE),
           ...options,
           elementSelector: GuideUtils.getElementSelector('.confirm-dialog .cancel-btn'),
           showOn: () => GuideUtils.isVisible('.confirm-dialog .cancel-btn'),

--- a/docs/guides_ttyg_ttyg-select-agent-dropdown-open.js.html
+++ b/docs/guides_ttyg_ttyg-select-agent-dropdown-open.js.html
@@ -124,7 +124,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, OPEN_AGENT_DROPDOWN),
           // If mainAction is set the title will be set automatically
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE),
           class: 'open-agent-dropdown',
           disableNextFlow: true,
           ...options,

--- a/docs/guides_ttyg_ttyg-select-agent-from-dropdown.js.html
+++ b/docs/guides_ttyg_ttyg-select-agent-from-dropdown.js.html
@@ -123,7 +123,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, SELECT_AGENT),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE),
           disableNextFlow: true,
           class: 'select-your-agent',
           ...options,

--- a/docs/guides_ttyg_ttyg-select-agent-info-message.js.html
+++ b/docs/guides_ttyg_ttyg-select-agent-info-message.js.html
@@ -122,7 +122,7 @@ const step = {
         guideBlockName: 'info-message',
         options: {
           content: translate(this.translationBundle, SELECT_AGENT_INFO),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE),
           class: 'select-ttyg-agent',
           skipPoint: true,
           skipButtonLabel: translate(this.translationBundle, SKIP_SECTION),

--- a/docs/guides_ttyg_ttyg-similarity-info-message.js.html
+++ b/docs/guides_ttyg_ttyg-similarity-info-message.js.html
@@ -123,7 +123,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, SIMILARITY_CONTENT),
           class: 'info-similarity-search',
-          ...(options.title ?? {title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE),
           ...options,
           url: 'ttyg'
         }

--- a/docs/guides_ttyg_ttyg-similarity-select-index.js.html
+++ b/docs/guides_ttyg_ttyg-similarity-select-index.js.html
@@ -124,7 +124,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, SELECT_INDEX),
           class: 'select-similarity-index',
-          ...(options.title ?? {title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE),
           ...options,
           elementSelector: GuideUtils.getGuideElementSelector('similarity-connector-select')
         }

--- a/docs/guides_ttyg_ttyg-similarity-toggle-off.js.html
+++ b/docs/guides_ttyg_ttyg-similarity-toggle-off.js.html
@@ -125,7 +125,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, DISABLE_TOGGLE),
           class: 'toggle-similarity-search',
-          ...(options.title ?? {title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE),
           ...options,
           disable: true,
           url: 'ttyg',

--- a/docs/guides_ttyg_ttyg-similarity-toggle-on.js.html
+++ b/docs/guides_ttyg_ttyg-similarity-toggle-on.js.html
@@ -125,7 +125,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, ENABLE_TOGGLE),
           class: 'toggle-similarity-search',
-          ...(options.title ?? {title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE),
           ...options,
           url: 'ttyg',
           elementSelector: GuideUtils.getGuideElementSelector('query-method-similarity_search'),

--- a/docs/guides_ttyg_ttyg-sparql-copy-query-text.js.html
+++ b/docs/guides_ttyg_ttyg-sparql-copy-query-text.js.html
@@ -126,7 +126,7 @@ const step = {
       {
         guideBlockName: 'copy-text-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           elementSelector: GuideUtils.getGuideElementSelector('sparql-query-input'),
           text: options.sparqlQuery,
           ...options,

--- a/docs/guides_ttyg_ttyg-sparql-method-disable.js.html
+++ b/docs/guides_ttyg_ttyg-sparql-method-disable.js.html
@@ -124,7 +124,7 @@ const step = {
         guideBlockName: 'toggle-element',
         options: {
           content: translate(this.translationBundle, DISABLE_TOGGLE),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           class: 'toggle-sparql-search',
           ...options,
           url: 'ttyg',

--- a/docs/guides_ttyg_ttyg-sparql-method-ontology-select.js.html
+++ b/docs/guides_ttyg_ttyg-sparql-method-ontology-select.js.html
@@ -125,7 +125,7 @@ const step = {
           content: translate(this.translationBundle, ENABLE_ONTOLOGY_FROM_GRAPH),
           class: 'enable-ontology-from-graph',
           // If mainAction is set the title will be set automatically
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           ...options,
           url: 'ttyg',
           elementSelector: GuideUtils.getGuideElementSelector('sparql-ontology-graph-option'),

--- a/docs/guides_ttyg_ttyg-sparql-method-sparql-query-select.js.html
+++ b/docs/guides_ttyg_ttyg-sparql-method-sparql-query-select.js.html
@@ -123,7 +123,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, ENABLE_SPARQL_QUERY),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           class: 'enable-sparql-query',
           url: 'ttyg',
           elementSelector: GuideUtils.getGuideElementSelector('sparql-query-option'),

--- a/docs/guides_visual-graph_visual-graph-config-click-tab.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-click-tab.js.html
@@ -145,7 +145,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_CLICK_TAB_CONTENT, {tab}),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           elementSelector: GuideUtils.getGuideElementSelector(`graph-config-tab-${tabConfig.index}`),
           ...options,

--- a/docs/guides_visual-graph_visual-graph-config-create-click.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-create-click.js.html
@@ -122,7 +122,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_CREATE_CLICK_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations',
           elementSelector: GuideUtils.getGuideElementSelector('create-graph-config-btn'),
           placement: 'left',

--- a/docs/guides_visual-graph_visual-graph-config-hint.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-hint.js.html
@@ -130,7 +130,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_PROPERTIES_HINT, {configHint}),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           ...options,
           elementSelector,

--- a/docs/guides_visual-graph_visual-graph-config-name.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-name.js.html
@@ -123,7 +123,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_PROPERTIES_NAME),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           scrollToHandler: GuideUtils.scrollToTop,
           ...options,

--- a/docs/guides_visual-graph_visual-graph-config-sample-query.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-sample-query.js.html
@@ -137,7 +137,7 @@ const step = {
         guideBlockName: 'read-only-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_SAMPLE_QUERY_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           elementSelector: GuideUtils.getGuideElementSelector(`sample-queries-${tabIndex}`),
           ...options

--- a/docs/guides_visual-graph_visual-graph-config-save.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-save.js.html
@@ -123,7 +123,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_SAVE_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           elementSelector,
           onNextClick: GuideUtils.clickOnElement(elementSelector),

--- a/docs/guides_visual-graph_visual-graph-config-select.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-select.js.html
@@ -123,7 +123,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_SELECT_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations',
           elementSelector,
           maxWaitTime: 10,

--- a/docs/guides_visual-graph_visual-graph-config-share.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-share.js.html
@@ -123,7 +123,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_SHARE_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           elementSelector,
           onNextValidate: () => Promise.resolve(GuideUtils.isChecked(elementSelector)),

--- a/docs/guides_visual-graph_visual-graph-config-starting-point-intro.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-starting-point-intro.js.html
@@ -121,7 +121,7 @@ const step = {
           url: 'graphs-visualizations/config/save',
           class: 'visual-graph-config-starting-point-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/docs/guides_visual-graph_visual-graph-config-starting-point.js.html
+++ b/docs/guides_visual-graph_visual-graph-config-starting-point.js.html
@@ -150,7 +150,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, config.contentKey),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           elementSelector: GuideUtils.getGuideElementSelector(config.elementSelector),
           onNextClick: GuideUtils.clickOnGuideElement(config.elementSelector),

--- a/docs/guides_visual-graph_visual-graph-intro.js.html
+++ b/docs/guides_visual-graph_visual-graph-intro.js.html
@@ -129,7 +129,7 @@ const step = {
         guideBlockName: 'read-only-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_INTRO_CONTENT, {iriLabel: options.iriLabel}),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_INTRO_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_INTRO_DEFAULT_TITLE),
           url: 'graphs-visualizations',
           elementSelector: '.graph-visualization',
           placement: 'left',

--- a/docs/guides_visual-graph_visual-graph-link-focus.js.html
+++ b/docs/guides_visual-graph_visual-graph-link-focus.js.html
@@ -136,7 +136,7 @@ const step = {
       {
         guideBlockName: 'read-only-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_LINK_FOCUS_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_LINK_FOCUS_TITLE),
           content: translate(this.translationBundle, VISUAL_GRAPH_LINK_FOCUS_CONTENT, {
             fromIriLabel: options.fromIriLabel,
             iriLabel: options.iriLabel,

--- a/docs/guides_visual-graph_visual-graph-node-focus.js.html
+++ b/docs/guides_visual-graph_visual-graph-node-focus.js.html
@@ -131,7 +131,7 @@ const step = {
       {
         guideBlockName: 'read-only-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_NODE_FOCUS_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_NODE_FOCUS_DEFAULT_TITLE),
           content: translate(this.translationBundle, VISUAL_GRAPH_NODE_FOCUS_CONTENT, {iriLabel: options.iriLabel}),
           url: 'graphs-visualizations',
           canBePaused: false,

--- a/docs/guides_visual-graph_visual-graph-search-rdf-resources-input-autocomplete-item.js.html
+++ b/docs/guides_visual-graph_visual-graph-search-rdf-resources-input-autocomplete-item.js.html
@@ -117,7 +117,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           // Title comes from options.title when provided, otherwise use translated default
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_AUTOCOMPLETE_ITEM_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_AUTOCOMPLETE_ITEM_DEFAULT_TITLE),
           content: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_AUTOCOMPLETE_ITEM_CONTENT, {iri: options.iri}),
           url: 'graphs-visualizations',
           elementSelector: GuideUtils.getGuideElementSelector(`autocomplete-${options.iri}`),

--- a/docs/guides_visual-graph_visual-graph-search-rdf-resources-input.js.html
+++ b/docs/guides_visual-graph_visual-graph-search-rdf-resources-input.js.html
@@ -116,7 +116,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           // Title comes from options.title when provided, otherwise use translated default
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_DEFAULT_TITLE),
           content: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_CONTENT, {easyGraphInputText: options.easyGraphInputText}),
           forceReload: true,
           url: 'graphs-visualizations',

--- a/docs/guides_visual-graph_visual-graph-set-maximum-links.js.html
+++ b/docs/guides_visual-graph_visual-graph-set-maximum-links.js.html
@@ -131,7 +131,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_SET_MAXIMUM_LINKS_CONTENT, {linkLimit}),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           ...options,
           elementSelector,
           onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(elementSelector, linkLimit))

--- a/docs/guides_visual-graph_visual-graph-settings-click.js.html
+++ b/docs/guides_visual-graph_visual-graph-settings-click.js.html
@@ -123,7 +123,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_SETTINGS_CLICK_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           elementSelector,
           onNextClick: GuideUtils.clickOnElement(elementSelector),
           ...options

--- a/docs/guides_visual-graph_visual-graph-settings-save.js.html
+++ b/docs/guides_visual-graph_visual-graph-settings-save.js.html
@@ -123,7 +123,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_SETTINGS_SAVE_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           elementSelector,
           onNextClick: GuideUtils.clickOnElement(elementSelector),
           ...options

--- a/docs/guides_visual-graph_visual-graph-zoom.js.html
+++ b/docs/guides_visual-graph_visual-graph-zoom.js.html
@@ -120,7 +120,7 @@ const step = {
     return [{
       guideBlockName: 'scroll-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+        title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
         content: translate(this.translationBundle, VISUAL_GRAPH_ZOOM_CONTENT),
         url: 'graphs-visualizations',
         ...options,

--- a/plugins/guides/autocomplete/autocomplete-enable-checkbox.js
+++ b/plugins/guides/autocomplete/autocomplete-enable-checkbox.js
@@ -22,9 +22,7 @@ const CONTENT = 'guide.step_plugin.autocomplete-enable-checkbox.content';
 const step = {
   guideBlockName: 'autocomplete-enable-checkbox',
   getSteps: function(options, services) {
-    const GuideUtils = services.GuideUtils;
     const translate = services.translate;
-    const autocompleteCheckboxSelector = GuideUtils.getGuideElementSelector('autocompleteCheckbox');
     let checkboxElement;
     let autocompleteCheckboxClickEventHandler;
     return [
@@ -32,21 +30,21 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, CONTENT),
-          ...(options.title ? {} : {title: translate(this.translationBundle, DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           class: 'enable-autocomplete-checkbox',
           ...options,
           url: 'autocomplete',
-          elementSelector: autocompleteCheckboxSelector,
+          elementSelector: services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'),
           // Disable default behavior of service when element is clicked.
           advanceOn: undefined,
-          beforeShowPromise: () => GuideUtils.deferredShow(500)(),
+          beforeShowPromise: () => services.GuideUtils.deferredShow(500)(),
           show: (guide) => () => {
-            checkboxElement = document.querySelector(autocompleteCheckboxSelector);
+            checkboxElement = document.querySelector(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'));
             autocompleteCheckboxClickEventHandler = () => {
               // If autocomplete is enabled go to the next step.
-              GuideUtils.deferredShow(200)()
+              services.GuideUtils.deferredShow(200)()
                 .then(() => {
-                  if (GuideUtils.isGuideElementChecked('autocompleteCheckbox', ' input')) {
+                  if (services.GuideUtils.isGuideElementChecked('autocompleteCheckbox', ' input')) {
                     guide.next();
                   }
                 });
@@ -55,7 +53,7 @@ const step = {
             checkboxElement.addEventListener('mouseup', autocompleteCheckboxClickEventHandler);
           },
           onNextClick: (guide) => {
-            if (!GuideUtils.isGuideElementChecked('autocompleteCheckbox', ' input')) {
+            if (!services.GuideUtils.isGuideElementChecked('autocompleteCheckbox', ' input')) {
               checkboxElement.click();
             }
             guide.next();

--- a/plugins/guides/autocomplete/autocomplete-focus-on-indexing-status.js
+++ b/plugins/guides/autocomplete/autocomplete-focus-on-indexing-status.js
@@ -24,17 +24,16 @@ const CONTENT = 'guide.step_plugin.autocomplete-focus-on-indexing-status.content
 const step = {
   guideBlockName: 'autocomplete-focus-on-indexing-status',
   getSteps: function(options, services) {
-    const GuideUtils = services.GuideUtils;
     const translate = services.translate;
 
     return {
       guideBlockName: 'read-only-element',
       options: {
         content: translate(this.translationBundle, CONTENT),
-        ...(options.title ? {} : {title: translate(this.translationBundle, DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, DEFAULT_TITLE),
         ...options,
         url: 'autocomplete',
-        elementSelector: GuideUtils.getGuideElementSelector('autocompleteStatus'),
+        elementSelector: services.GuideUtils.getGuideElementSelector('autocompleteStatus'),
         class: 'autocomplete-status-info',
         canBePaused: false
       }

--- a/plugins/guides/class-relationships/class-relationships-class-list-background-intro.js
+++ b/plugins/guides/class-relationships/class-relationships-class-list-background-intro.js
@@ -33,7 +33,7 @@ const step = {
           placement: 'right',
           class: 'class-relationships-class-list-background-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/plugins/guides/class-relationships/class-relationships-class-list-intro.js
+++ b/plugins/guides/class-relationships/class-relationships-class-list-intro.js
@@ -33,7 +33,7 @@ const step = {
           placement: 'right',
           class: 'class-relationships-class-list-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/plugins/guides/class-relationships/class-relationships-class-list-selection.js
+++ b/plugins/guides/class-relationships/class-relationships-class-list-selection.js
@@ -32,7 +32,7 @@ const step = {
           placement: 'right',
           class: 'class-relationships-class-list-selection',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/plugins/guides/class-relationships/class-relationships-diagram-intro.js
+++ b/plugins/guides/class-relationships/class-relationships-diagram-intro.js
@@ -32,7 +32,7 @@ const step = {
           placement: 'left',
           class: 'class-relationships-diagram-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/plugins/guides/class-relationships/class-relationships-digram-predicates-intro.js
+++ b/plugins/guides/class-relationships/class-relationships-digram-predicates-intro.js
@@ -33,7 +33,7 @@ const step = {
           placement: 'left',
           class: 'class-relationships-digram-predicates-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/plugins/guides/class-relationships/class-relationships-digram-thickness-intro.js
+++ b/plugins/guides/class-relationships/class-relationships-digram-thickness-intro.js
@@ -33,7 +33,7 @@ const step = {
           placement: 'left',
           class: 'class-relationships-digram-thickness-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/plugins/guides/class-relationships/class-relationships-intro.js
+++ b/plugins/guides/class-relationships/class-relationships-intro.js
@@ -30,7 +30,7 @@ const step = {
           class: 'clas-hierarchy-intro',
           placement: 'left',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/plugins/guides/class-relationships/class-relationships-named-graph-selection.js
+++ b/plugins/guides/class-relationships/class-relationships-named-graph-selection.js
@@ -35,7 +35,7 @@ const step = {
           class: 'class-relationships-named-graph-selection',
           content: translate(this.translationBundle, CONTENT),
           scrollToHandler: () => GuideUtils.scrollIntoView(elementSelector, {block: 'center'}),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/plugins/guides/connectors/connectors-array-subparameter-intro.js
+++ b/plugins/guides/connectors/connectors-array-subparameter-intro.js
@@ -68,7 +68,7 @@ const step = {
     return [{
       guideBlockName: 'read-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-connector-intro',
         content: translate(this.translationBundle, SUBPARAMETER_INTRO),

--- a/plugins/guides/connectors/connectors-close-view-sparql-query-dialog.js
+++ b/plugins/guides/connectors/connectors-close-view-sparql-query-dialog.js
@@ -29,7 +29,7 @@ const step = {
     return [{
       guideBlockName: 'clickable-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-close-view-sparql-query-dialog',
         content: translate(this.translationBundle, CLOSE_VIEW_SPARQL_DIALOG),

--- a/plugins/guides/connectors/connectors-connector-intro.js
+++ b/plugins/guides/connectors/connectors-connector-intro.js
@@ -53,7 +53,7 @@ const step = {
     return [{
       guideBlockName: 'read-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-connector-intro',
         content: translate(this.translationBundle, CONNECTORS_INTRO_CONTENT),

--- a/plugins/guides/connectors/connectors-expand-connector.js
+++ b/plugins/guides/connectors/connectors-expand-connector.js
@@ -52,7 +52,7 @@ const step = {
     return [{
       guideBlockName: 'clickable-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-expand-connector',
         content: translate(this.translationBundle, EXPAND_CONNECTOR_CONTENT),

--- a/plugins/guides/connectors/connectors-open-view-sparql-query-dialog.js
+++ b/plugins/guides/connectors/connectors-open-view-sparql-query-dialog.js
@@ -54,7 +54,7 @@ const step = {
     return [{
       guideBlockName: 'clickable-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'open-view-sparql-query-dialog',
         content: translate(this.translationBundle, OPEN_VIEW_SPARQL_DIALOG),

--- a/plugins/guides/connectors/connectors-parameter-fields-remaining-fields-intro.js
+++ b/plugins/guides/connectors/connectors-parameter-fields-remaining-fields-intro.js
@@ -58,7 +58,7 @@ const step = {
 
     return [{
       guideBlockName: 'read-only-element', options: {
-        ...(options.title ?? {title: translate(step.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(step.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-remaining-fieldsets-intro',
         content: translate(step.translationBundle, REMAINING_FIELDS_INTRO),

--- a/plugins/guides/connectors/connectors-parameter-intro.js
+++ b/plugins/guides/connectors/connectors-parameter-intro.js
@@ -55,7 +55,7 @@ const step = {
     return [{
       guideBlockName: 'read-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-connector-intro',
         content: translate(this.translationBundle, PARAMETER_INTRO),

--- a/plugins/guides/connectors/connectors-type-intro.js
+++ b/plugins/guides/connectors/connectors-type-intro.js
@@ -48,7 +48,7 @@ const step = {
     return [{
       guideBlockName: 'read-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'top',
         class: 'connectors-connectors-intro',
         content: translate(this.translationBundle, CONNECTOR_TYPE_INTRO),

--- a/plugins/guides/connectors/connectors-view-sparql-dialog-intro.js
+++ b/plugins/guides/connectors/connectors-view-sparql-dialog-intro.js
@@ -29,7 +29,7 @@ const step = {
     return [{
       guideBlockName: 'scroll-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, CONNECTORS_DEFAULT_TITLE),
         placement: 'left',
         class: 'connectors-view-sparql-dialog-intro',
         content: translate(this.translationBundle, VIEW_SPARQL_DIALOG),

--- a/plugins/guides/connectors/lucene/connectors-expand-lucene.js
+++ b/plugins/guides/connectors/lucene/connectors-expand-lucene.js
@@ -40,7 +40,7 @@ const step = {
       guideBlockName: 'connectors-expand-connector',
       options: {
         content: translate(this.translationBundle, LUCENE_EXPAND_CONTENT, {instanceName: options.instanceName}),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         connectorName: LUCENE_CONNECTOR_NAME,
         class: 'connectors-lucene-expand'

--- a/plugins/guides/connectors/lucene/connectors-lucene-analyzer-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-analyzer-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, ANALYZER_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-analyzer-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-boost-properties-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-boost-properties-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, BOOST_PROPERTIES),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-boost-properties-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-detect-fields-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-detect-fields-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, DETECT_FIELDS),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-detect-fields-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-analyzed-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-analyzed-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, ANALYZED_INTRO_CONTENT),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-analyzed-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-datatype-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-datatype-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, DATATYPE_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-datatype-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-default-value-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-default-value-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, DEFAULT_VALUE_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-default-value-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-facet-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-facet-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, FACET_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-facet-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-field-name-transform-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-field-name-transform-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, TRANSFORM_INTRO_CONTENT),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-field-name-transform-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-ignore-invalid-values-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-ignore-invalid-values-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, INVALID_VALUES_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-ignore-invalid-values-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-indexed-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-indexed-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, INDEXED_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-indexed-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-intro.js
@@ -36,7 +36,7 @@ const step = {
       options: {
         content: translate(this.translationBundle, FIELD_INTRO_CONTENT),
         scrollOffset: GuideUtils.SCROLL_OFFSET.CENTER,
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-multivalued-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-multivalued-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, MULTIVALUED_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-multivalued-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-property-chain-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-property-chain-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, PROPERTY_CHAIN_INTRO_CONTENT),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-property-chain-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-remaining-fields-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-remaining-fields-intro.js
@@ -34,7 +34,7 @@ const step = {
       guideBlockName: 'connectors-parameter-fields-remaining-fields-intro',
       options: {
         content: translate(step.translationBundle, REMAINING_FIELDS_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-remaining-fields-intro',
         parameterName: 'fields',

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-stored-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-stored-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, STORED_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-stored-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-fields-value-filter-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-fields-value-filter-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-array-subparameter-intro',
       options: {
         content: translate(this.translationBundle, VALUE_FILTER_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-fields-value-filter-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-import-file-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-import-file-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, IMPORT_FILE),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-import-file-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-import-graph-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-import-graph-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, IMPORT_GRAPH),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-import-graph-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-languages-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-languages-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, LANGUAGES_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-languages-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-open-view-sparql-query-dialog.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-open-view-sparql-query-dialog.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-open-view-sparql-query-dialog',
       options: {
         content: translate(this.translationBundle, OPEN_SPARQL),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-open-view-sparql-query-dialog',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-readonly-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-readonly-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, READONLY_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-readonly-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-skip-initial-indexing-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-skip-initial-indexing-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, SKIP_INITIAL_INDEXING),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-skip-initial-indexing-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-strip-markup-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-strip-markup-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, STRIP_MARKUP),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-strip-markup-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-type-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-type-intro.js
@@ -31,7 +31,7 @@ const step = {
       guideBlockName: 'connectors-type-intro',
       options: {
         content: translate(this.translationBundle, LUCENE_TYPE_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         connectorName: LUCENE_CONNECTOR_NAME,
         class: 'connectors-lucene-type-intro'

--- a/plugins/guides/connectors/lucene/connectors-lucene-types-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-types-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, TYPES_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-types-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-value-filter-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-value-filter-intro.js
@@ -35,7 +35,7 @@ const step = {
       guideBlockName: 'connectors-parameter-intro',
       options: {
         content: translate(this.translationBundle, VALUE_FILTER_INTRO),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-value-filter-intro',
         connectorName: LUCENE_CONNECTOR_NAME,

--- a/plugins/guides/connectors/lucene/connectors-lucene-view-sparql-dialog-intro.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene-view-sparql-dialog-intro.js
@@ -30,7 +30,7 @@ const step = {
       guideBlockName: 'connectors-view-sparql-dialog-intro',
       options: {
         content: translate(this.translationBundle, VIEW_SPARQL_DIALOG),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         class: 'connectors-lucene-view-sparql-dialog-intro'
       }

--- a/plugins/guides/connectors/lucene/connectors-lucene.js
+++ b/plugins/guides/connectors/lucene/connectors-lucene.js
@@ -40,7 +40,7 @@ const step = {
       guideBlockName: 'connectors-connector-intro',
       options: {
         content: translate(this.translationBundle, LUCENE_CONTENT, {instanceName: options.instanceName}),
-        ...(options.title ?? {title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, LUCENE_DEFAULT_TITLE),
         ...options,
         connectorName: LUCENE_CONNECTOR_NAME,
         class: 'connectors-lucene'

--- a/plugins/guides/import/import-click-on-import-button.js
+++ b/plugins/guides/import/import-click-on-import-button.js
@@ -31,7 +31,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(step.translationBundle, CONTENT),
-          ...(options.title ? {} : {title: translate(step.translationBundle, DEFAULT_TITLE)}),
+          title: translate(step.translationBundle, DEFAULT_TITLE),
           placement: 'top',
           class: 'import-settings-import-file-button',
           ...options,

--- a/plugins/guides/import/import-confirm-duplicate-files.js
+++ b/plugins/guides/import/import-confirm-duplicate-files.js
@@ -29,7 +29,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(step.translationBundle, CONTENT),
-          ...(options.title ? {} : {title: translate(step.translationBundle, DEFAULT_TITLE)}),
+          title: translate(step.translationBundle, DEFAULT_TITLE),
           placement: 'bottom',
           class: 'import-file-button',
           ...options,

--- a/plugins/guides/import/import-show-progress.js
+++ b/plugins/guides/import/import-show-progress.js
@@ -33,7 +33,7 @@ const step = {
         guideBlockName: 'read-only-element',
         options: {
           content: translate(step.translationBundle, CONTENT),
-          ...(options.title ? {} : {title: translate(step.translationBundle, DEFAULT_TITLE)}),
+          title: translate(step.translationBundle, DEFAULT_TITLE),
           class: 'import-status-info',
           ...options,
           url: 'import',

--- a/plugins/guides/import/import-upload-rdf-file.js
+++ b/plugins/guides/import/import-upload-rdf-file.js
@@ -42,7 +42,7 @@ const step = {
         options: {
           content: translate(step.translationBundle, CONTENT, {resourceFile: options.resourceFile}),
           class: 'upload-rdf-file-button',
-          ...(options.title ? {} : {title: translate(step.translationBundle, DEFAULT_TITLE)}),
+          title: translate(step.translationBundle, DEFAULT_TITLE),
           ...options,
           url: 'import',
           elementSelector: GuideUtils.getGuideElementSelector('uploadRdfFileButton'),

--- a/plugins/guides/main-menu/click-main-menu.js
+++ b/plugins/guides/main-menu/click-main-menu.js
@@ -91,7 +91,6 @@ const step = {
   guideBlockName: 'click-main-menu',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
     const steps = [];
 
     let menuSelector;
@@ -254,7 +253,7 @@ const step = {
     }
 
     const menuLabel = translate(this.translationBundle, menuTitle);
-    const elementSelector = GuideUtils.getGuideElementSelector(menuSelector);
+    const elementSelector = services.GuideUtils.getGuideElementSelector(menuSelector);
     // Main menu element
     steps.push({
       guideBlockName: 'clickable-element',
@@ -263,9 +262,9 @@ const step = {
         class: menuDialogClass,
         elementSelector,
         beforeShowPromise: () => {
-          if (!!submenuSelector && GuideUtils.isGuideElementVisible(submenuSelector)) {
+          if (!!submenuSelector && services.GuideUtils.isGuideElementVisible(submenuSelector)) {
             return new Promise((resolve) => {
-              GuideUtils.clickOnGuideElement(menuSelector, mainMenuClickElementPostSelector)();
+              services.GuideUtils.clickOnGuideElement(menuSelector, mainMenuClickElementPostSelector)();
               // Needed to wait the layout to complete, before painting, thus avoiding ResizeObserver loop error
               setTimeout(resolve, 500);
             });
@@ -273,8 +272,8 @@ const step = {
           return Promise.resolve();
         },
 
-        onNextClick: GuideUtils.clickOnGuideElement(menuSelector, mainMenuClickElementPostSelector),
-        scrollToHandler: () => GuideUtils.scrollIntoView(elementSelector, {block: 'center'}),
+        onNextClick: services.GuideUtils.clickOnGuideElement(menuSelector, mainMenuClickElementPostSelector),
+        scrollToHandler: () => services.GuideUtils.scrollIntoView(elementSelector, {block: 'center'}),
         initPreviousStep: (services, stepId) => {
           const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);
           if (previousStep) {
@@ -287,9 +286,9 @@ const step = {
       }
     });
 
-    const submenuLabel = translate(this.translationBundle, submenuTitle);
     if (submenuSelector) {
-      const elementSubmenuSelector = GuideUtils.getGuideElementSelector(submenuSelector);
+      const submenuLabel = translate(this.translationBundle, submenuTitle);
+      const elementSubmenuSelector = services.GuideUtils.getGuideElementSelector(submenuSelector);
       steps.push({
         guideBlockName: 'clickable-element',
         options: {
@@ -298,8 +297,8 @@ const step = {
           elementSelector: elementSubmenuSelector,
           placement: 'right',
           canBePaused: false,
-          onNextClick: GuideUtils.clickOnGuideElement(submenuSelector, ' a'),
-          scrollToHandler: () => GuideUtils.scrollIntoView(elementSubmenuSelector, {block: 'center'}),
+          onNextClick: services.GuideUtils.clickOnGuideElement(submenuSelector, ' a'),
+          scrollToHandler: () => services.GuideUtils.scrollIntoView(elementSubmenuSelector, {block: 'center'}),
           initPreviousStep: (services, stepId) => {
             const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);
             if (previousStep) {

--- a/plugins/guides/rdf-rank/rdf-rank-compute-fill.js
+++ b/plugins/guides/rdf-rank/rdf-rank-compute-fill.js
@@ -33,7 +33,7 @@ const step = {
           url: 'rdfrank',
           content: translate(this.translationBundle, COMPUTE_FILL),
           elementSelector: computeRDFRankButtonSelector,
-          ...(options.title ?? {title: translate(this.translationBundle, RDF_RANK_TITLE)}),
+          title: translate(this.translationBundle, RDF_RANK_TITLE),
           onNextClick: GuideUtils.clickOnElement( computeRDFRankButtonSelector),
           ...options
         }

--- a/plugins/guides/repositories/repositories-select-repository.js
+++ b/plugins/guides/repositories/repositories-select-repository.js
@@ -40,7 +40,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, SELECT_REPO_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_DEFAULT_TITLE),
           url: 'repository',
           elementSelector: selectRepositoryButtonWrapperSelector,
           class: 'repositories-select-repository',

--- a/plugins/guides/repository/repositories-create-graphdb.js
+++ b/plugins/guides/repository/repositories-create-graphdb.js
@@ -30,7 +30,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, GRAPHDB_REPOSITORY_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'create-gdb-repository',
           ...options,
           url: 'repository/create',

--- a/plugins/guides/repository/repositories-create-repository.js
+++ b/plugins/guides/repository/repositories-create-repository.js
@@ -30,7 +30,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, CREATE_REPO_BUTTON),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'create-repository',
           ...options,
           url: 'repository',

--- a/plugins/guides/repository/repositories-enable-fts.js
+++ b/plugins/guides/repository/repositories-enable-fts.js
@@ -31,7 +31,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, ENABLE_FTS_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'gdb-repository-enable-fts',
           extraContent: translate(this.translationBundle, EXTRA_CONTENT),
           extraContentClass: 'alert alert-help text-left',

--- a/plugins/guides/repository/repositories-id-input.js
+++ b/plugins/guides/repository/repositories-id-input.js
@@ -32,7 +32,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, REPOSITORY_ID_CONTENT, {repositoryId: options.repositoryId}),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'gdb-repository-id-input',
           ...options,
           url: 'repository/create/graphdb',

--- a/plugins/guides/repository/repositories-ruleset-dropdown.js
+++ b/plugins/guides/repository/repositories-ruleset-dropdown.js
@@ -35,7 +35,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, DROPDOWN_CONTENT, {rulesetName: options.rulesetName}),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'gdb-repository-ruleset-select',
           ...options,
           url: 'repository/create/graphdb',

--- a/plugins/guides/repository/repositories-save.js
+++ b/plugins/guides/repository/repositories-save.js
@@ -31,7 +31,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, SAVE_BUTTON),
-          ...(options.title ?? {title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, REPOSITORIES_CREATE_DEFAULT_TITLE),
           class: 'create-repository-button',
           ...options,
           url: 'repository/create/graphdb',

--- a/plugins/guides/resource/resource-search-autocomplete-item.js
+++ b/plugins/guides/resource/resource-search-autocomplete-item.js
@@ -36,7 +36,7 @@ const step = {
       {
         guideBlockName: 'clickable-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, RESOURCE_SEARCH_AUTOCOMPLETE_ITEM_TITLE)}),
+          title: translate(this.translationBundle, RESOURCE_SEARCH_AUTOCOMPLETE_ITEM_TITLE),
           content: translate(this.translationBundle, RESOURCE_SEARCH_AUTOCOMPLETE_ITEM_CONTENT, {iri: options.iri}),
           elementSelector: GuideUtils.getGuideElementSelector(`autocomplete-${options.iri}`),
           onNextClick: (guide, step) => GuideUtils.waitFor(step.elementSelector, 3).then(() => $(step.elementSelector).trigger('click')),

--- a/plugins/guides/resource/resource-search-rdf.js
+++ b/plugins/guides/resource/resource-search-rdf.js
@@ -40,7 +40,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, RESOURCE_SEARCH_RDF_CONTENT, {searchTerm}),
-          ...(options.title ?? {title: translate(this.translationBundle, RESOURCE_SEARCH_RDF_TITLE)}),
+          title: translate(this.translationBundle, RESOURCE_SEARCH_RDF_TITLE),
           ...options,
           elementSelector,
           onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(elementSelector, searchTerm))

--- a/plugins/guides/similarity-index/similarity-click-link.js
+++ b/plugins/guides/similarity-index/similarity-click-link.js
@@ -30,7 +30,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, CREATE_INDEX),
-          ...(options.title ?? {title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT)}),
+          title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
           class: 'similarity-index',
           disableNextFlow: true,
           ...options,

--- a/plugins/guides/similarity-index/similarity-click-to-create.js
+++ b/plugins/guides/similarity-index/similarity-click-to-create.js
@@ -30,7 +30,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, CREATE_INDEX),
-          ...(options.title ?? {title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT)}),
+          title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
           class: 'create-similarity-index',
           disablePreviousFlow: false,
           disableNextFlow: true,

--- a/plugins/guides/similarity-index/similarity-hold-and-wait-until-shown.js
+++ b/plugins/guides/similarity-index/similarity-hold-and-wait-until-shown.js
@@ -28,7 +28,7 @@ const step = {
       {
         guideBlockName: 'hold-and-wait-until-shown',
         options: {
-          title: options.title ?? translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
+          title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
           content: translate(this.translationBundle, WAIT_FOR_INDEX),
           class: 'wait-for-index',
           ...options,

--- a/plugins/guides/similarity-index/similarity-type-index-name.js
+++ b/plugins/guides/similarity-index/similarity-type-index-name.js
@@ -30,7 +30,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, INPUT_INDEX_NAME),
-          ...(options.title ?? {title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT)}),
+          title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
           class: 'similarity-index-name-input',
           ...options,
           url: 'similarity/index/create',

--- a/plugins/guides/similarity-index/similarity-view-created-index.js
+++ b/plugins/guides/similarity-index/similarity-view-created-index.js
@@ -56,7 +56,7 @@ const step = {
           content,
           url: 'similarity',
           class: 'view-created-index',
-          ...(options.title ?? {title: CREATE_SIMILARITY_INDEX_DEFAULT}),
+          title: translate(this.translationBundle, CREATE_SIMILARITY_INDEX_DEFAULT),
           ...options,
           elementSelector
         }

--- a/plugins/guides/sparql-editor/execute-sparql-query.js
+++ b/plugins/guides/sparql-editor/execute-sparql-query.js
@@ -57,11 +57,7 @@ const step = {
   guideBlockName: 'execute-sparql-query',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
-    const toastr = services.toastr;
-    const $translate = services.$translate;
-    const $interpolate = services.$interpolate;
-    const RoutingUtil = services.RoutingUtil;
+
     options.mainAction = 'execute-sparql-query';
     options.title = options.title ?? translate(this.translationBundle, SPARQL_EDITOR_TITLE);
 
@@ -91,8 +87,8 @@ const step = {
           query,
           queryExtraContent: queryDef.queryExtraContent,
           beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
-            .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
-            .then(() => GuideUtils.deferredShow(500)())
+            .then(() => services.GuideUtils.waitFor(services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
+            .then(() => services.GuideUtils.deferredShow(500)())
             .catch((error) => {
               services.toastr.error(translate(this.translationBundle, UNEXPECTED_ERROR));
               throw error;
@@ -100,14 +96,14 @@ const step = {
           onNextValidate: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then((yasgui) => yasgui.getQuery().then((query) => ({yasgui, queryFromEditor: query})))
             .then(({yasgui, queryFromEditor}) => {
-              const editorQuery = GuideUtils.removeWhiteSpaces(queryFromEditor);
-              const stepQuery = GuideUtils.removeWhiteSpaces(query);
+              const editorQuery = services.GuideUtils.removeWhiteSpaces(queryFromEditor);
+              const stepQuery = services.GuideUtils.removeWhiteSpaces(query);
               if (editorQuery !== stepQuery) {
                 if (editorQuery === 'select*where{?s?p?o.}limit100' || overwriteQuery) {
                   // The query is the default query OR we previously overwrote it => we can overwrite it
                   yasgui.setQuery(query);
                 } else {
-                  GuideUtils.noNextErrorToast(toastr, $translate, $interpolate,
+                  services.GuideUtils.noNextErrorToast(services.toastr, services.$translate, services.$interpolate,
                     QUERY_NOT_SAME_ERROR, options);
                   return false;
                 }
@@ -120,13 +116,13 @@ const step = {
               return services.YasguiComponentUtil.setQuery(Utils.SPARQL_DIRECTIVE_SELECTOR, defaultQuery);
             }
 
-            const haveToReload = 'sparql' !== RoutingUtil.getCurrentRoute();
+            const haveToReload = 'sparql' !== services.RoutingUtil.getCurrentRoute();
 
             if (haveToReload) {
-              RoutingUtil.navigate('/sparql');
+              services.RoutingUtil.navigate('/sparql');
             }
 
-            return GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
+            return services.GuideUtils.waitFor(services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
               .then(() => services.YasguiComponentUtil.executeSparqlQuery('#query-editor', query));
           },
           ...options
@@ -156,10 +152,10 @@ const step = {
         options: {
           extraContent: queryDef.resultExtraContent,
           initPreviousStep: (services, stepId) => {
-            if ('sparql' !== RoutingUtil.getCurrentRoute()) {
-              RoutingUtil.navigate('/sparql');
-              return GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
-                .then(() => GuideUtils.deferredShow(500)())
+            if ('sparql' !== services.RoutingUtil.getCurrentRoute()) {
+              services.RoutingUtil.navigate('/sparql');
+              return services.GuideUtils.waitFor(services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR)
+                .then(() => services.GuideUtils.deferredShow(500)())
                 .then(() => services.YasguiComponentUtil.executeSparqlQuery('#query-editor', query));
             }
 

--- a/plugins/guides/sparql-editor/sparql-editor-expand-results-over-owl.js
+++ b/plugins/guides/sparql-editor/sparql-editor-expand-results-over-owl.js
@@ -28,7 +28,7 @@ const step = {
       {
         guideBlockName: 'read-only-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           content: translate(this.translationBundle, EXPAND_RESULTS_CONTENT),
           url: 'sparql',
           elementSelector: '.yasqe_expandResultsButton',

--- a/plugins/guides/sparql-editor/sparql-editor-include-inferred-data.js
+++ b/plugins/guides/sparql-editor/sparql-editor-include-inferred-data.js
@@ -28,7 +28,7 @@ const step = {
       {
         guideBlockName: 'read-only-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           content: translate(this.translationBundle, INCLUDE_INFERRED_CONTENT),
           url: 'sparql',
           elementSelector: '.yasqe_inferStatementsButton',

--- a/plugins/guides/sparql-editor/sparql-editor-run-button.js
+++ b/plugins/guides/sparql-editor/sparql-editor-run-button.js
@@ -26,22 +26,22 @@ const step = {
   guideBlockName: 'sparql-editor-run-button',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
+
     return [
       {
         guideBlockName: 'clickable-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           content: translate(this.translationBundle, RUN_QUERY),
           url: 'sparql',
-          elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_RUN_BUTTON_SELECTOR,
+          elementSelector: services.GuideUtils.CSS_SELECTORS.SPARQL_RUN_BUTTON_SELECTOR,
           class: 'yasgui-run-button',
           onNextClick: (guide) => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
             .then((yasgui) => {
               yasgui.query();
               guide.next();
             }),
-          scrollToHandler: GuideUtils.scrollToTop,
+          scrollToHandler: services.GuideUtils.scrollToTop,
           ...options
         }
       }

--- a/plugins/guides/sparql-editor/sparql-editor.js
+++ b/plugins/guides/sparql-editor/sparql-editor.js
@@ -36,7 +36,6 @@ const step = {
   guideBlockName: 'sparql-editor',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
 
     const code = document.createElement('code');
     const copy = document.createElement('button');
@@ -54,14 +53,14 @@ const step = {
       {
         guideBlockName: 'input-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           content: translate(this.translationBundle, QUERY_EDITOR_CONTENT, {queryAsHtmlCodeElement}),
           url: 'sparql',
-          elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
+          elementSelector: services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
           class: 'yasgui-query-editor',
           beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
-            .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
-            .then(() => GuideUtils.deferredShow(500)())
+            .then(() => services.GuideUtils.waitFor(services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
+            .then(() => services.GuideUtils.deferredShow(500)())
             .catch((error) => {
               services.toastr.error(translate(this.translationBundle, UNEXPECTED_ERROR));
               throw error;
@@ -72,7 +71,7 @@ const step = {
               yasgui.setQuery(query);
               return true;
             }),
-          scrollToHandler: GuideUtils.scrollToTop,
+          scrollToHandler: services.GuideUtils.scrollToTop,
           extraContent: options.queryExtraContent,
           show: (_guide) => () => {
             stepHTMLElement = _guide.currentStep.el.querySelector(`.${copyToEditorButtonClass}`);

--- a/plugins/guides/sparql-editor/sparql-explain-editor.js
+++ b/plugins/guides/sparql-editor/sparql-explain-editor.js
@@ -30,23 +30,22 @@ const step = {
   guideBlockName: 'sparql-explain-editor',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
     return [
       {
         guideBlockName: 'input-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           url: 'sparql',
-          elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
+          elementSelector: services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR,
           class: 'sparql-explain-editor',
           beforeShowPromise: () => services.YasguiComponentUtil.getOntotextYasguiElementAsync(Utils.SPARQL_DIRECTIVE_SELECTOR)
-            .then(() => GuideUtils.waitFor(GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
-            .then(() => GuideUtils.deferredShow(500)())
+            .then(() => services.GuideUtils.waitFor(services.GuideUtils.CSS_SELECTORS.SPARQL_EDITOR_SELECTOR, 3))
+            .then(() => services.GuideUtils.deferredShow(500)())
             .catch((error) => {
               services.toastr.error(translate(this.translationBundle, UNEXPECTED_ERROR));
               throw error;
             }),
-          scrollToHandler: GuideUtils.scrollToTop,
+          scrollToHandler: services.GuideUtils.scrollToTop,
           extraContent: options.extraContent,
           ...options
         }

--- a/plugins/guides/sparql-editor/sparql-results-click-on-iri.js
+++ b/plugins/guides/sparql-editor/sparql-results-click-on-iri.js
@@ -30,21 +30,20 @@ const step = {
   guideBlockName: 'sparql-results-click-on-iri',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
     return [
       {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, CLICK_ON_IRI, {iriLabel: options.iriLabel}),
           placement: 'top',
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           ...options,
-          scrollToHandler: GuideUtils.scrollToTop,
-          elementSelector: GuideUtils.getSparqlResultsSelectorForIri(options.iri),
+          scrollToHandler: services.GuideUtils.scrollToTop,
+          elementSelector: services.GuideUtils.getSparqlResultsSelectorForIri(options.iri),
           class: 'table-graph-instance',
-          url: '/sparql',
+          url: 'sparql',
           onNextClick: (guide, step) => {
-            GuideUtils.waitFor(step.elementSelector, 3)
+            services.GuideUtils.waitFor(step.elementSelector, 3)
               .then(() => document.querySelector(step.elementSelector).click());
           }
         }

--- a/plugins/guides/sparql-editor/sparql-results-explain.js
+++ b/plugins/guides/sparql-editor/sparql-results-explain.js
@@ -24,19 +24,18 @@ const step = {
   guideBlockName: 'sparql-results-explain',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
     return [
       {
         guideBlockName: 'read-only-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           content: translate(this.translationBundle, EXPLAIN_CONTENT),
           url: 'sparql',
           placement: 'top',
-          elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_RESULTS_SELECTOR,
+          elementSelector: services.GuideUtils.CSS_SELECTORS.SPARQL_RESULTS_SELECTOR,
           class: 'yasgui-query-results',
           fileName: options.fileName,
-          scrollToHandler: GuideUtils.scrollToTop,
+          scrollToHandler: services.GuideUtils.scrollToTop,
           extraContent: options.resultExtraContent,
           canBePaused: false,
           ...options

--- a/plugins/guides/sparql-editor/sparql-results-visual-button.js
+++ b/plugins/guides/sparql-editor/sparql-results-visual-button.js
@@ -24,18 +24,17 @@ const step = {
   guideBlockName: 'sparql-results-visual-button',
   getSteps: function(options, services) {
     const translate = services.translate;
-    const GuideUtils = services.GuideUtils;
     return [
       {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, SPARQL_RESULT_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, SPARQL_EDITOR_TITLE)}),
+          title: translate(this.translationBundle, SPARQL_EDITOR_TITLE),
           url: 'sparql',
-          elementSelector: GuideUtils.CSS_SELECTORS.SPARQL_VISUAL_BUTTON_SELECTOR,
+          elementSelector: services.GuideUtils.CSS_SELECTORS.SPARQL_VISUAL_BUTTON_SELECTOR,
           class: 'visual-sparql-results-button',
-          scrollToHandler: GuideUtils.scrollToTop,
-          onNextClick: () => GuideUtils.clickOnElement(GuideUtils.CSS_SELECTORS.SPARQL_VISUAL_BUTTON_SELECTOR)(),
+          scrollToHandler: services.GuideUtils.scrollToTop,
+          onNextClick: () => services.GuideUtils.clickOnElement(services.GuideUtils.CSS_SELECTORS.SPARQL_VISUAL_BUTTON_SELECTOR)(),
           ...options
         }
       }

--- a/plugins/guides/ttyg/configure-agent-additional-instructions.js
+++ b/plugins/guides/ttyg/configure-agent-additional-instructions.js
@@ -36,7 +36,7 @@ const step = {
         guideBlockName: 'copy-text-element',
         options: {
           extraContent: translate(this.translationBundle, CONFIGURE_USER_INSTRUCTIONS),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
           class: 'input-user-instructions',
           disablePreviousFlow: false,
           text: options.userInstructions,

--- a/plugins/guides/ttyg/configure-agent-type-agent-name.js
+++ b/plugins/guides/ttyg/configure-agent-type-agent-name.js
@@ -34,7 +34,7 @@ const step = {
           content: translate(this.translationBundle, CONFIGURE_AGENT_NAME),
           class: 'input-agent-name',
           disablePreviousFlow: false,
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
           ...options,
           url: 'ttyg',
           beforeShowPromise: () => GuideUtils.waitFor(GuideUtils.getGuideElementSelector('agent-form'), 5)

--- a/plugins/guides/ttyg/configure-agent-type-model-name.js
+++ b/plugins/guides/ttyg/configure-agent-type-model-name.js
@@ -37,7 +37,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, CONFIGURE_AGENT_MODEL, {model: options.model}),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
           class: 'input-model',
           disablePreviousFlow: false,
           ...options,

--- a/plugins/guides/ttyg/configure-autocomplete-iri-discovery.js
+++ b/plugins/guides/ttyg/configure-autocomplete-iri-discovery.js
@@ -47,7 +47,7 @@ const step = {
       options: {
         content,
         class: 'toggle-autocomplete-iri-discovery',
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         ...options,
         url: 'ttyg',
         elementSelector: GuideUtils.getGuideElementSelector('autocomplete-iri-discovery'),

--- a/plugins/guides/ttyg/configure-iri-discovery-search.js
+++ b/plugins/guides/ttyg/configure-iri-discovery-search.js
@@ -48,7 +48,7 @@ const step = {
       options: {
         content,
         class: 'toggle-iri-discovery-search',
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         ...options,
         url: 'ttyg',
         elementSelector,

--- a/plugins/guides/ttyg/configure-temperature.js
+++ b/plugins/guides/ttyg/configure-temperature.js
@@ -44,7 +44,7 @@ const step = {
         class: 'configure-temperature',
         content: translate(this.translationBundle, CONFIGURE_TEMPERATURE_INFO, {temperature: options.temperature}),
         onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(inputSelector, options.temperature)),
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         ...options
       }
     };

--- a/plugins/guides/ttyg/configure-top-p.js
+++ b/plugins/guides/ttyg/configure-top-p.js
@@ -44,7 +44,7 @@ const step = {
         class: 'configure-top-p',
         content: translate(this.translationBundle, CONFIGURE_TOP_P, {topP: options.topP}),
         onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(inputSelector, options.topP)),
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         ...options
       }
     };

--- a/plugins/guides/ttyg/set-context-window-size.js
+++ b/plugins/guides/ttyg/set-context-window-size.js
@@ -43,7 +43,7 @@ const step = {
         class: 'set-context-window-size',
         content: translate(this.translationBundle, SET_CONTEXT_WINDOW_SIZE, {contextSize: options.contextSize}),
         onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(inputSelector, options.contextSize)),
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         ...options
       }
     };

--- a/plugins/guides/ttyg/set-max-iris-per-call.js
+++ b/plugins/guides/ttyg/set-max-iris-per-call.js
@@ -38,7 +38,7 @@ const step = {
       guideBlockName: 'input-element',
       options: {
         content: translate(this.translationBundle, SET_MAX_IRIS_PER_CALL, {maxIrisPerCall}),
-        ...(options.title ?? {title: translate(this.translationBundle, TTYG_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, TTYG_DEFAULT_TITLE),
         class: 'set-max-iris-per-call',
         ...options,
         url: 'ttyg',

--- a/plugins/guides/ttyg/set-max-triples-per-call.js
+++ b/plugins/guides/ttyg/set-max-triples-per-call.js
@@ -36,7 +36,7 @@ const step = {
       guideBlockName: 'input-element',
       options: {
         content: translate(this.translationBundle, SET_MAX_TRIPLES_PER_CALL, {maxTriplesPerCall: options.maxTriplesPerCall}),
-        ...(options.title ?? {title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE)}),
+        title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE),
         class: 'toggle-fts-search',
         ...options,
         url: 'ttyg',

--- a/plugins/guides/ttyg/sparql-search-method-type-graph-name.js
+++ b/plugins/guides/ttyg/sparql-search-method-type-graph-name.js
@@ -37,7 +37,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, TYPE_ONTLOGY_GRAPH, {ontologyGraph: options.ontologyGraph}),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           class: 'input-ontology-graph-name',
           ...options,
           url: 'ttyg',

--- a/plugins/guides/ttyg/ttyg-click-to-edit-selected-agent.js
+++ b/plugins/guides/ttyg/ttyg-click-to-edit-selected-agent.js
@@ -31,7 +31,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, EDIT_TTYG_AGENT),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE),
           class: 'edit-agent-btn',
           disableNextFlow: true,
           ...options,

--- a/plugins/guides/ttyg/ttyg-edit-agent-click-to-save.js
+++ b/plugins/guides/ttyg/ttyg-edit-agent-click-to-save.js
@@ -31,7 +31,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, SAVE_AGENT),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE),
           class: 'save-agent',
           disablePreviousFlow: false,
           disableNextFlow: true,

--- a/plugins/guides/ttyg/ttyg-edit-agent-intro-message.js
+++ b/plugins/guides/ttyg/ttyg-edit-agent-intro-message.js
@@ -31,7 +31,7 @@ const step = {
         guideBlockName: 'info-message',
         options: {
           content: translate(this.translationBundle, EDIT_TTYG_AGENT),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_EDIT_AGENT_DEFAULT_TITLE),
           skipPoint: true,
           skipButtonLabel: translate(this.translationBundle, SKIP_SECTION),
           ...options

--- a/plugins/guides/ttyg/ttyg-enabling-sparql-info-message.js
+++ b/plugins/guides/ttyg/ttyg-enabling-sparql-info-message.js
@@ -30,7 +30,7 @@ const step = {
         guideBlockName: 'info-message',
         options: {
           content: translate(this.translationBundle, SEARCH_METHOD_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           class: 'info-sparql-search',
           ...options,
           url: 'ttyg'

--- a/plugins/guides/ttyg/ttyg-fts-method-disable.js
+++ b/plugins/guides/ttyg/ttyg-fts-method-disable.js
@@ -33,7 +33,7 @@ const step = {
         guideBlockName: 'toggle-element',
         options: {
           content: translate(this.translationBundle, DISABLE_TOGGLE),
-          ...(options.title ?? {title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE),
           class: 'toggle-fts-search',
           ...options,
           disable: true,

--- a/plugins/guides/ttyg/ttyg-fts-method-enable.js
+++ b/plugins/guides/ttyg/ttyg-fts-method-enable.js
@@ -33,7 +33,7 @@ const step = {
         guideBlockName: 'toggle-element',
         options: {
           content: translate(this.translationBundle, ENABLE_TOGGLE),
-          ...(options.title ?? {title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE),
           class: 'toggle-fts-search',
           ...options,
           url: 'ttyg',

--- a/plugins/guides/ttyg/ttyg-fts-method-info.js
+++ b/plugins/guides/ttyg/ttyg-fts-method-info.js
@@ -32,7 +32,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, FTS_SEARCH_CONTENT),
           // If mainAction is set the title will be set automatically
-          ...(options.title ?? {title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, FTS_METHOD_DEFAULT_TITLE),
           class: 'info-fts-search',
           ...options,
           url: 'ttyg'

--- a/plugins/guides/ttyg/ttyg-select-agent-check-for-missing-repository-cancel.js
+++ b/plugins/guides/ttyg/ttyg-select-agent-check-for-missing-repository-cancel.js
@@ -50,7 +50,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, MISSING_REPOSITORY),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE),
           ...options,
           elementSelector: GuideUtils.getElementSelector('.confirm-dialog .cancel-btn'),
           showOn: () => GuideUtils.isVisible('.confirm-dialog .cancel-btn'),

--- a/plugins/guides/ttyg/ttyg-select-agent-dropdown-open.js
+++ b/plugins/guides/ttyg/ttyg-select-agent-dropdown-open.js
@@ -33,7 +33,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, OPEN_AGENT_DROPDOWN),
           // If mainAction is set the title will be set automatically
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE),
           class: 'open-agent-dropdown',
           disableNextFlow: true,
           ...options,

--- a/plugins/guides/ttyg/ttyg-select-agent-from-dropdown.js
+++ b/plugins/guides/ttyg/ttyg-select-agent-from-dropdown.js
@@ -32,7 +32,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, SELECT_AGENT),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE),
           disableNextFlow: true,
           class: 'select-your-agent',
           ...options,

--- a/plugins/guides/ttyg/ttyg-select-agent-info-message.js
+++ b/plugins/guides/ttyg/ttyg-select-agent-info-message.js
@@ -31,7 +31,7 @@ const step = {
         guideBlockName: 'info-message',
         options: {
           content: translate(this.translationBundle, SELECT_AGENT_INFO),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SELECT_AGENT_DEFAULT_TITLE),
           class: 'select-ttyg-agent',
           skipPoint: true,
           skipButtonLabel: translate(this.translationBundle, SKIP_SECTION),

--- a/plugins/guides/ttyg/ttyg-similarity-info-message.js
+++ b/plugins/guides/ttyg/ttyg-similarity-info-message.js
@@ -32,7 +32,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, SIMILARITY_CONTENT),
           class: 'info-similarity-search',
-          ...(options.title ?? {title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE),
           ...options,
           url: 'ttyg'
         }

--- a/plugins/guides/ttyg/ttyg-similarity-select-index.js
+++ b/plugins/guides/ttyg/ttyg-similarity-select-index.js
@@ -33,7 +33,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, SELECT_INDEX),
           class: 'select-similarity-index',
-          ...(options.title ?? {title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE),
           ...options,
           elementSelector: GuideUtils.getGuideElementSelector('similarity-connector-select')
         }

--- a/plugins/guides/ttyg/ttyg-similarity-toggle-off.js
+++ b/plugins/guides/ttyg/ttyg-similarity-toggle-off.js
@@ -34,7 +34,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, DISABLE_TOGGLE),
           class: 'toggle-similarity-search',
-          ...(options.title ?? {title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE),
           ...options,
           disable: true,
           url: 'ttyg',

--- a/plugins/guides/ttyg/ttyg-similarity-toggle-on.js
+++ b/plugins/guides/ttyg/ttyg-similarity-toggle-on.js
@@ -34,7 +34,7 @@ const step = {
         options: {
           content: translate(this.translationBundle, ENABLE_TOGGLE),
           class: 'toggle-similarity-search',
-          ...(options.title ?? {title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, SIMILARITY_SEARCH_METHOD_DEFAULT_TITLE),
           ...options,
           url: 'ttyg',
           elementSelector: GuideUtils.getGuideElementSelector('query-method-similarity_search'),

--- a/plugins/guides/ttyg/ttyg-sparql-copy-query-text.js
+++ b/plugins/guides/ttyg/ttyg-sparql-copy-query-text.js
@@ -35,7 +35,7 @@ const step = {
       {
         guideBlockName: 'copy-text-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           elementSelector: GuideUtils.getGuideElementSelector('sparql-query-input'),
           text: options.sparqlQuery,
           ...options,

--- a/plugins/guides/ttyg/ttyg-sparql-method-disable.js
+++ b/plugins/guides/ttyg/ttyg-sparql-method-disable.js
@@ -33,7 +33,7 @@ const step = {
         guideBlockName: 'toggle-element',
         options: {
           content: translate(this.translationBundle, DISABLE_TOGGLE),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           class: 'toggle-sparql-search',
           ...options,
           url: 'ttyg',

--- a/plugins/guides/ttyg/ttyg-sparql-method-ontology-select.js
+++ b/plugins/guides/ttyg/ttyg-sparql-method-ontology-select.js
@@ -34,7 +34,7 @@ const step = {
           content: translate(this.translationBundle, ENABLE_ONTOLOGY_FROM_GRAPH),
           class: 'enable-ontology-from-graph',
           // If mainAction is set the title will be set automatically
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           ...options,
           url: 'ttyg',
           elementSelector: GuideUtils.getGuideElementSelector('sparql-ontology-graph-option'),

--- a/plugins/guides/ttyg/ttyg-sparql-method-sparql-query-select.js
+++ b/plugins/guides/ttyg/ttyg-sparql-method-sparql-query-select.js
@@ -32,7 +32,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, ENABLE_SPARQL_QUERY),
-          ...(options.title ?? {title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, TTYG_SPARQL_SEARCH_METHOD_DEFAULT_TITLE),
           class: 'enable-sparql-query',
           url: 'ttyg',
           elementSelector: GuideUtils.getGuideElementSelector('sparql-query-option'),

--- a/plugins/guides/visual-graph/visual-graph-config-click-tab.js
+++ b/plugins/guides/visual-graph/visual-graph-config-click-tab.js
@@ -54,7 +54,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_CLICK_TAB_CONTENT, {tab}),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           elementSelector: GuideUtils.getGuideElementSelector(`graph-config-tab-${tabConfig.index}`),
           ...options,

--- a/plugins/guides/visual-graph/visual-graph-config-create-click.js
+++ b/plugins/guides/visual-graph/visual-graph-config-create-click.js
@@ -31,7 +31,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_CREATE_CLICK_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations',
           elementSelector: GuideUtils.getGuideElementSelector('create-graph-config-btn'),
           placement: 'left',

--- a/plugins/guides/visual-graph/visual-graph-config-hint.js
+++ b/plugins/guides/visual-graph/visual-graph-config-hint.js
@@ -39,7 +39,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_PROPERTIES_HINT, {configHint}),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           ...options,
           elementSelector,

--- a/plugins/guides/visual-graph/visual-graph-config-name.js
+++ b/plugins/guides/visual-graph/visual-graph-config-name.js
@@ -32,7 +32,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_PROPERTIES_NAME),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           scrollToHandler: GuideUtils.scrollToTop,
           ...options,

--- a/plugins/guides/visual-graph/visual-graph-config-sample-query.js
+++ b/plugins/guides/visual-graph/visual-graph-config-sample-query.js
@@ -46,7 +46,7 @@ const step = {
         guideBlockName: 'read-only-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_SAMPLE_QUERY_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           elementSelector: GuideUtils.getGuideElementSelector(`sample-queries-${tabIndex}`),
           ...options

--- a/plugins/guides/visual-graph/visual-graph-config-save.js
+++ b/plugins/guides/visual-graph/visual-graph-config-save.js
@@ -32,7 +32,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_SAVE_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           elementSelector,
           onNextClick: GuideUtils.clickOnElement(elementSelector),

--- a/plugins/guides/visual-graph/visual-graph-config-select.js
+++ b/plugins/guides/visual-graph/visual-graph-config-select.js
@@ -32,7 +32,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_SELECT_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations',
           elementSelector,
           maxWaitTime: 10,

--- a/plugins/guides/visual-graph/visual-graph-config-share.js
+++ b/plugins/guides/visual-graph/visual-graph-config-share.js
@@ -32,7 +32,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_CONFIG_SHARE_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           elementSelector,
           onNextValidate: () => Promise.resolve(GuideUtils.isChecked(elementSelector)),

--- a/plugins/guides/visual-graph/visual-graph-config-starting-point-intro.js
+++ b/plugins/guides/visual-graph/visual-graph-config-starting-point-intro.js
@@ -30,7 +30,7 @@ const step = {
           url: 'graphs-visualizations/config/save',
           class: 'visual-graph-config-starting-point-intro',
           content: translate(this.translationBundle, CONTENT),
-          title: options.title ?? translate(this.translationBundle, DEFAULT_TITLE),
+          title: translate(this.translationBundle, DEFAULT_TITLE),
           ...options
         }
       }

--- a/plugins/guides/visual-graph/visual-graph-config-starting-point.js
+++ b/plugins/guides/visual-graph/visual-graph-config-starting-point.js
@@ -59,7 +59,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, config.contentKey),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           url: 'graphs-visualizations/config/save',
           elementSelector: GuideUtils.getGuideElementSelector(config.elementSelector),
           onNextClick: GuideUtils.clickOnGuideElement(config.elementSelector),

--- a/plugins/guides/visual-graph/visual-graph-intro.js
+++ b/plugins/guides/visual-graph/visual-graph-intro.js
@@ -38,7 +38,7 @@ const step = {
         guideBlockName: 'read-only-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_INTRO_CONTENT, {iriLabel: options.iriLabel}),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_INTRO_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_INTRO_DEFAULT_TITLE),
           url: 'graphs-visualizations',
           elementSelector: '.graph-visualization',
           placement: 'left',

--- a/plugins/guides/visual-graph/visual-graph-link-focus.js
+++ b/plugins/guides/visual-graph/visual-graph-link-focus.js
@@ -45,7 +45,7 @@ const step = {
       {
         guideBlockName: 'read-only-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_LINK_FOCUS_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_LINK_FOCUS_TITLE),
           content: translate(this.translationBundle, VISUAL_GRAPH_LINK_FOCUS_CONTENT, {
             fromIriLabel: options.fromIriLabel,
             iriLabel: options.iriLabel,

--- a/plugins/guides/visual-graph/visual-graph-node-focus.js
+++ b/plugins/guides/visual-graph/visual-graph-node-focus.js
@@ -40,7 +40,7 @@ const step = {
       {
         guideBlockName: 'read-only-element',
         options: {
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_NODE_FOCUS_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_NODE_FOCUS_DEFAULT_TITLE),
           content: translate(this.translationBundle, VISUAL_GRAPH_NODE_FOCUS_CONTENT, {iriLabel: options.iriLabel}),
           url: 'graphs-visualizations',
           canBePaused: false,

--- a/plugins/guides/visual-graph/visual-graph-search-rdf-resources-input-autocomplete-item.js
+++ b/plugins/guides/visual-graph/visual-graph-search-rdf-resources-input-autocomplete-item.js
@@ -26,7 +26,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           // Title comes from options.title when provided, otherwise use translated default
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_AUTOCOMPLETE_ITEM_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_AUTOCOMPLETE_ITEM_DEFAULT_TITLE),
           content: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_AUTOCOMPLETE_ITEM_CONTENT, {iri: options.iri}),
           url: 'graphs-visualizations',
           elementSelector: GuideUtils.getGuideElementSelector(`autocomplete-${options.iri}`),

--- a/plugins/guides/visual-graph/visual-graph-search-rdf-resources-input.js
+++ b/plugins/guides/visual-graph/visual-graph-search-rdf-resources-input.js
@@ -25,7 +25,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           // Title comes from options.title when provided, otherwise use translated default
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_DEFAULT_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_DEFAULT_TITLE),
           content: translate(this.translationBundle, VISUAL_GRAPH_SEARCH_RDF_RESOURCES_INPUT_CONTENT, {easyGraphInputText: options.easyGraphInputText}),
           forceReload: true,
           url: 'graphs-visualizations',

--- a/plugins/guides/visual-graph/visual-graph-set-maximum-links.js
+++ b/plugins/guides/visual-graph/visual-graph-set-maximum-links.js
@@ -40,7 +40,7 @@ const step = {
         guideBlockName: 'input-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_SET_MAXIMUM_LINKS_CONTENT, {linkLimit}),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           ...options,
           elementSelector,
           onNextValidate: () => Promise.resolve(GuideUtils.validateTextInput(elementSelector, linkLimit))

--- a/plugins/guides/visual-graph/visual-graph-settings-click.js
+++ b/plugins/guides/visual-graph/visual-graph-settings-click.js
@@ -32,7 +32,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_SETTINGS_CLICK_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           elementSelector,
           onNextClick: GuideUtils.clickOnElement(elementSelector),
           ...options

--- a/plugins/guides/visual-graph/visual-graph-settings-save.js
+++ b/plugins/guides/visual-graph/visual-graph-settings-save.js
@@ -32,7 +32,7 @@ const step = {
         guideBlockName: 'clickable-element',
         options: {
           content: translate(this.translationBundle, VISUAL_GRAPH_SETTINGS_SAVE_CONTENT),
-          ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+          title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
           elementSelector,
           onNextClick: GuideUtils.clickOnElement(elementSelector),
           ...options

--- a/plugins/guides/visual-graph/visual-graph-zoom.js
+++ b/plugins/guides/visual-graph/visual-graph-zoom.js
@@ -29,7 +29,7 @@ const step = {
     return [{
       guideBlockName: 'scroll-only-element',
       options: {
-        ...(options.title ?? {title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE)}),
+        title: translate(this.translationBundle, VISUAL_GRAPH_EXPLORE_TITLE),
         content: translate(this.translationBundle, VISUAL_GRAPH_ZOOM_CONTENT),
         url: 'graphs-visualizations',
         ...options,


### PR DESCRIPTION
## What
- Stop caching GuideUtils
- Fix title string being spread char-by-char into step options
- Guard submenuLabel before translating

## Why
- Cached services break dynamic injection
- Spreading a string title decomposed it into indexed characters
- Undefined submenuLabel produced invalid translation keys

## How
- Access services.GuideUtils inline
- assign title as a property instead of spreading it
- skip translate when submenuLabel is absent