### PR TITLE
GDB-14800: Remove browser history usage from the class-hierarchy-instances step

### DIFF
--- a/docs/guides_class-hierarchy_class-hierarchy-instances.js.html
+++ b/docs/guides_class-hierarchy_class-hierarchy-instances.js.html
@@ -213,11 +213,16 @@ const step = {
       });
     }
 
+    let urlBeforeFollowCountLink = null;
+
     if (options.followCountLink) {
       steps.push({
         guideBlockName: 'class-hierarchy-rdf-instances-side-panel-open-all-instances-in-sparql',
         options: {
           title,
+          show: () => () => {
+            urlBeforeFollowCountLink = window.location.href;
+          },
           ...options
         }
       });
@@ -239,7 +244,7 @@ const step = {
           extraContent,
           content: pluginService.translate(this.translationBundle, RESULTS_CONTENT),
           onNextClick: (guide) => {
-            window.history.back();
+            RoutingUtil.navigate(urlBeforeFollowCountLink);
             guide.next();
           },
           initPreviousStep: () => Promise.resolve(),

--- a/plugins/guides/class-hierarchy/class-hierarchy-instances.js
+++ b/plugins/guides/class-hierarchy/class-hierarchy-instances.js
@@ -122,11 +122,16 @@ const step = {
       });
     }
 
+    let urlBeforeFollowCountLink = null;
+
     if (options.followCountLink) {
       steps.push({
         guideBlockName: 'class-hierarchy-rdf-instances-side-panel-open-all-instances-in-sparql',
         options: {
           title,
+          show: () => () => {
+            urlBeforeFollowCountLink = window.location.href;
+          },
           ...options
         }
       });
@@ -148,7 +153,7 @@ const step = {
           extraContent,
           content: pluginService.translate(this.translationBundle, RESULTS_CONTENT),
           onNextClick: (guide) => {
-            window.history.back();
+            RoutingUtil.navigate(urlBeforeFollowCountLink);
             guide.next();
           },
           initPreviousStep: () => Promise.resolve(),


### PR DESCRIPTION
## What
Remove the dependency on the browser history in the class-hierarchy-instances step.

## Why
The existing implementation relies on the browser history being in an expected state. This causes issues when the Workbench implementation changes, as the browser history no longer matches the expected navigation flow.

## How
Instead of relying on the browser history, the step now stores the current URL before navigating to the instances view. When returning to the step with the opened sidebar, the saved URL is used to restore the page with the required URL parameters.