### PR TITLE
GDB-14833 fix unresponsive autocomplete step

### DIFF
--- a/docs/guides_autocomplete_autocomplete-enable-checkbox.js.html
+++ b/docs/guides_autocomplete_autocomplete-enable-checkbox.js.html
@@ -128,7 +128,7 @@ const step = {
           elementSelector: services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'),
           // Disable default behavior of service when element is clicked.
           advanceOn: undefined,
-          beforeShowPromise: () => services.GuideUtils.deferredShow(500)(),
+          beforeShowPromise: () => services.GuideUtils.getOrWaitFor(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox')),
           show: (guide) => () => {
             checkboxElement = document.querySelector(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'));
             autocompleteCheckboxClickEventHandler = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphdb-workbench-plugins",
-  "version": "0.0.1-TR36",
+  "version": "0.0.1-TR37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphdb-workbench-plugins",
-      "version": "0.0.1-TR36",
+      "version": "0.0.1-TR37",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphdb-workbench-plugins",
-  "version": "0.0.1-TR36",
+  "version": "0.0.1-TR37",
   "description": "Plugins for GraphDB workbench",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugins/guides/autocomplete/autocomplete-enable-checkbox.js
+++ b/plugins/guides/autocomplete/autocomplete-enable-checkbox.js
@@ -37,7 +37,7 @@ const step = {
           elementSelector: services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'),
           // Disable default behavior of service when element is clicked.
           advanceOn: undefined,
-          beforeShowPromise: () => services.GuideUtils.deferredShow(500)(),
+          beforeShowPromise: () => services.GuideUtils.getOrWaitFor(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox')),
           show: (guide) => () => {
             checkboxElement = document.querySelector(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'));
             autocompleteCheckboxClickEventHandler = () => {


### PR DESCRIPTION
## What
Fix unresponsive behavior in the autocomplete step.

## Why
The step was shown before the checkbox was visible on occasion, which caused an error.

## How
Modified the `beforeShowPromise` to wait for the checkbox element instead of a hard 500 deferred show

## Testing
n/a