### PR TITLE
GDB-14833 increase autocomplete waiting time

### DIFF
--- a/docs/guides_autocomplete_autocomplete-enable-checkbox.js.html
+++ b/docs/guides_autocomplete_autocomplete-enable-checkbox.js.html
@@ -128,7 +128,7 @@ const step = {
           elementSelector: services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'),
           // Disable default behavior of service when element is clicked.
           advanceOn: undefined,
-          beforeShowPromise: () => services.GuideUtils.getOrWaitFor(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox')),
+          beforeShowPromise: () => services.GuideUtils.getOrWaitFor(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'), 5),
           show: (guide) => () => {
             checkboxElement = document.querySelector(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'));
             autocompleteCheckboxClickEventHandler = () => {

--- a/plugins/guides/autocomplete/autocomplete-enable-checkbox.js
+++ b/plugins/guides/autocomplete/autocomplete-enable-checkbox.js
@@ -37,7 +37,7 @@ const step = {
           elementSelector: services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'),
           // Disable default behavior of service when element is clicked.
           advanceOn: undefined,
-          beforeShowPromise: () => services.GuideUtils.getOrWaitFor(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox')),
+          beforeShowPromise: () => services.GuideUtils.getOrWaitFor(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'), 5),
           show: (guide) => () => {
             checkboxElement = document.querySelector(services.GuideUtils.getGuideElementSelector('autocompleteCheckbox'));
             autocompleteCheckboxClickEventHandler = () => {


### PR DESCRIPTION
## What
Increase waiting time for autocomplete to improve responsiveness.

## Why
It was using the default 1 second, which isn't enough on slower networks

## How
Added a 5 second max waiting time, instead of the default 1

## Testing
n/a