### PR TITLE
GDB-14958: Fix visual graph expand reload synchronization

### DIFF
--- a/docs/guides_visual-graph_visual-graph-expand.js.html
+++ b/docs/guides_visual-graph_visual-graph-expand.js.html
@@ -169,13 +169,10 @@ const step = {
           beforeShowPromise: () => {
             $route.reload();
             // in some cases reloading starts after the defer and alpha drop. In such cases the step is shown, the page is
-            // reloaded and shepherd detaches from the element. Wait until the element is hidden to ensure the reload has
-            // started and then wait for the d3 alpha to drop, so we ensure the correct order
-            return GuideUtils.waitUntilHidden(elementSelector)
-              .then(() => GuideUtils.deferredShow(50)())
-              .then(() => {
-                return GuideUtils.awaitAlphaDropD3(elementSelector, $rootScope)();
-              });
+            // reloaded and shepherd detaches from the element. We do two deferred shows to ensure the reload has started and then wait for the d3 alpha to drop, so we ensure the correct order
+            return GuideUtils.deferredShow()()
+              .then(GuideUtils.deferredShow(50))
+              .then(GuideUtils.awaitAlphaDropD3(elementSelector, $rootScope));
           },
           initPreviousStep: (services, stepId) => {
             const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);

--- a/plugins/guides/visual-graph/visual-graph-expand.js
+++ b/plugins/guides/visual-graph/visual-graph-expand.js
@@ -78,13 +78,10 @@ const step = {
           beforeShowPromise: () => {
             $route.reload();
             // in some cases reloading starts after the defer and alpha drop. In such cases the step is shown, the page is
-            // reloaded and shepherd detaches from the element. Wait until the element is hidden to ensure the reload has
-            // started and then wait for the d3 alpha to drop, so we ensure the correct order
-            return GuideUtils.waitUntilHidden(elementSelector)
-              .then(() => GuideUtils.deferredShow(50)())
-              .then(() => {
-                return GuideUtils.awaitAlphaDropD3(elementSelector, $rootScope)();
-              });
+            // reloaded and shepherd detaches from the element. We do two deferred shows to ensure the reload has started and then wait for the d3 alpha to drop, so we ensure the correct order
+            return GuideUtils.deferredShow()()
+              .then(GuideUtils.deferredShow(50))
+              .then(GuideUtils.awaitAlphaDropD3(elementSelector, $rootScope));
           },
           initPreviousStep: (services, stepId) => {
             const previousStep = services.ShepherdService.getPreviousStepFromHistory(stepId);


### PR DESCRIPTION
## What
- Adjusted the deferred execution order in the visual graph expand step handler to ensure proper synchronization of route reload and D3 alpha drop.

## Why
- Previously, the reload timing was indetermined and the element might hide and show too fast before the step is shown which caused an exception

## How
- Replaced `waitUntilHidden` with two consecutive `GuideUtils.deferredShow` calls.
- Streamlined the promise chain to ensure deferred execution order is honored.